### PR TITLE
Add minimal manifest - no RBAC rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - ./$EXE_NAME --help || test $? -eq 2
   - |
     if [ "$TRAVIS_OS_NAME" = linux ]; then
-      make controller.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
+      make controller.yaml controller-norbac.yaml CONTROLLER_IMAGE=$CONTROLLER_IMAGE
     fi
 
 after_script: set +e
@@ -67,6 +67,7 @@ deploy:
   file:
     - $EXE_NAME
     - controller.yaml
+    - controller-norbac.yaml
   on:
     go: 1.8
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,13 @@ else
 endif
 	mv $@.tmp $@
 
-controller.yaml: controller.jsonnet controller.image
+%.yaml: %.jsonnet
 	$(KUBECFG) show -o yaml $< > $@.tmp
 	mv $@.tmp $@
+
+controller.yaml: controller.jsonnet controller.image controller-norbac.jsonnet
+
+controller-norbac.yaml: controller-norbac.jsonnet controller.image
 
 test:
 	$(GO) test $(GO_FLAGS) $(GO_PACKAGES)
@@ -51,6 +55,7 @@ fmt:
 clean:
 	$(RM) ./controller ./kubeseal
 	$(RM) *-static
+	$(RM) controller*.yaml
 	$(RM) docker/controller
 
 .PHONY: all test clean vet fmt

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -1,0 +1,62 @@
+// Minimal required deployment for a functional TPR + controller.
+local k = import "ksonnet.beta.1/k.libsonnet";
+
+local objectMeta = k.core.v1.objectMeta;
+local deployment = k.apps.v1beta1.deployment;
+local container = k.core.v1.container;
+local probe = k.core.v1.probe;
+local service = k.core.v1.service;
+local servicePort = k.core.v1.servicePort;
+
+local trim = function(str) (
+  if std.startsWith(str, " ") || std.startsWith(str, "\n") then
+  trim(std.substr(str, 1, std.length(str) - 1))
+  else if std.endsWith(str, " ") || std.endsWith(str, "\n") then
+  trim(std.substr(str, 0, std.length(str) - 1))
+  else
+    str
+);
+
+local namespace = "kube-system";
+
+local controllerImage = trim(importstr "controller.image");
+local controllerPort = 8080;
+
+local controllerProbe =
+  probe.default() +
+  probe.mixin.httpGet.path("/healthz") +
+  probe.mixin.httpGet.port(controllerPort);
+
+local controllerContainer =
+  container.default("sealed-secrets-controller", controllerImage) +
+  container.command(["controller"]) +
+  container.livenessProbe(controllerProbe) +
+  container.readinessProbe(controllerProbe) +
+  container.helpers.namedPort("http", controllerPort);
+
+local labels = {name: "sealed-secrets-controller"};
+
+local tpr = {
+  apiVersion: "extensions/v1beta1",
+  kind: "ThirdPartyResource",
+  metadata: objectMeta.name("sealed-secret.bitnami.com"),
+  versions: [{name: "v1alpha1"}],
+  description: "A sealed (encrypted) Secret",
+};
+
+local controllerDeployment =
+  deployment.default("sealed-secrets-controller", controllerContainer, namespace) +
+  {spec+: {template+: {metadata: {labels: labels}}}};
+
+local controllerSvc =
+  service.default("sealed-secrets-controller", namespace) +
+  service.spec(k.core.v1.serviceSpec.default()) +
+  service.mixin.spec.selector(labels) +
+  service.mixin.spec.ports([servicePort.default(controllerPort)]);
+
+{
+  namespace:: namespace,
+  tpr: k.util.prune(tpr),
+  controller: k.util.prune(controllerDeployment),
+  service: k.util.prune(controllerSvc),
+}

--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -1,11 +1,11 @@
+// This is the recommended cluster deployment of sealed-secrets.
+// See controller-norbac.jsonnet for the bare minimum functionality.
+
 local k = import "ksonnet.beta.1/k.libsonnet";
+local controller = import "controller-norbac.jsonnet";
 
 local objectMeta = k.core.v1.objectMeta;
 local deployment = k.apps.v1beta1.deployment;
-local container = k.core.v1.container;
-local probe = k.core.v1.probe;
-local service = k.core.v1.service;
-local servicePort = k.core.v1.servicePort;
 local serviceAccount = k.core.v1.serviceAccount;
 
 local clusterRole(name, rules) = {
@@ -58,41 +58,7 @@ local roleBinding(name, namespace="default", role, subjects) = {
   roleRef: crossGroupRef(role),
 };
 
-local trim = function(str) (
-  if std.startsWith(str, " ") || std.startsWith(str, "\n") then
-  trim(std.substr(str, 1, std.length(str) - 1))
-  else if std.endsWith(str, " ") || std.endsWith(str, "\n") then
-  trim(std.substr(str, 0, std.length(str) - 1))
-  else
-    str
-);
-
-local namespace = "kube-system";
-
-local controllerImage = trim(importstr "controller.image");
-local controllerPort = 8080;
-
-local controllerProbe =
-  probe.default() +
-  probe.mixin.httpGet.path("/healthz") +
-  probe.mixin.httpGet.port(controllerPort);
-
-local controllerContainer =
-  container.default("sealed-secrets-controller", controllerImage) +
-  container.command(["controller"]) +
-  container.livenessProbe(controllerProbe) +
-  container.readinessProbe(controllerProbe) +
-  container.helpers.namedPort("http", controllerPort);
-
-local labels = {name: "sealed-secrets-controller"};
-
-local tpr = {
-  apiVersion: "extensions/v1beta1",
-  kind: "ThirdPartyResource",
-  metadata: objectMeta.name("sealed-secret.bitnami.com"),
-  versions: [{name: "v1alpha1"}],
-  description: "A sealed (encrypted) Secret",
-};
+local namespace = controller.namespace;
 
 local controllerAccount =
   serviceAccount.default("sealed-secrets-controller", namespace);
@@ -125,26 +91,15 @@ local sealKeyRole = role("sealed-secrets-key-admin", namespace, [
   },
 ]);
 
-local binding = clusterRoleBinding("sealed-secrets-controller", unsealerRole, [controllerAccount]);
-local binding = roleBinding("sealed-secrets-controller", namespace, sealKeyRole, [controllerAccount]);
+local unsealerBinding = clusterRoleBinding("sealed-secrets-controller", unsealerRole, [controllerAccount]);
+local unsealKeyBinding = roleBinding("sealed-secrets-controller", namespace, sealKeyRole, [controllerAccount]);
 
-local controllerDeployment =
-  deployment.default("sealed-secrets-controller", controllerContainer, namespace) +
-  deployment.mixin.podSpec.serviceAccountName(controllerAccount.metadata.name) +
-  {spec+: {template+: {metadata: {labels: labels}}}};
-
-local controllerSvc =
-  service.default("sealed-secrets-controller", namespace) +
-  service.spec(k.core.v1.serviceSpec.default()) +
-  service.mixin.spec.selector(labels) +
-  service.mixin.spec.ports([servicePort.default(controllerPort)]);
-
-{
-  tpr: k.util.prune(tpr),
-  controller: k.util.prune(controllerDeployment),
-  service: k.util.prune(controllerSvc),
+controller + {
+  controller+: deployment.mixin.podSpec.serviceAccountName(
+    controllerAccount.metadata.name),
   account: k.util.prune(controllerAccount),
   unsealerRole: unsealerRole,
   unsealKeyRole: sealKeyRole,
-  binding: binding,
+  unsealerBinding: unsealerBinding,
+  unsealKeyBinding: unsealKeyBinding,
 }


### PR DESCRIPTION
RBAC doesn't work on Azure atm, and the additional RBAC rules may also
be undesirable in other future situations.

This change adds and publishes a `controller-norbac.yaml` which is the
bare minimum required for controller functionality (TPR and controller
service/deployment).

Fixes #17