### PR TITLE
Improve controller security

### DIFF
--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -32,6 +32,8 @@ local controllerContainer =
   container.command(["controller"]) +
   container.livenessProbe(controllerProbe) +
   container.readinessProbe(controllerProbe) +
+  container.mixin.securityContext.readOnlyRootFilesystem(true) +
+  container.mixin.securityContext.runAsUser(1001) +
   container.helpers.namedPort("http", controllerPort);
 
 local labels = {name: "sealed-secrets-controller"};

--- a/controller-norbac.jsonnet
+++ b/controller-norbac.jsonnet
@@ -32,8 +32,10 @@ local controllerContainer =
   container.command(["controller"]) +
   container.livenessProbe(controllerProbe) +
   container.readinessProbe(controllerProbe) +
+  container.securityContext(k.core.v1.podSecurityContext.default()) +
   container.mixin.securityContext.readOnlyRootFilesystem(true) +
-  container.mixin.securityContext.runAsUser(1001) +
+  container.mixin.securityContext.runAsNonRoot(true) +
+  {securityContext+: {runAsUser: 1001}} +
   container.helpers.namedPort("http", controllerPort);
 
 local labels = {name: "sealed-secrets-controller"};


### PR DESCRIPTION
This PR will make the controller image to run as non-root user. The file system will also be read-only.

```
$ kubectl exec -it -n kube-system sealed-secrets-controller-222321944-q4npb -- sh
/ $ id
uid=1001 gid=0(root)
/ $ touch /tmp/test
touch: /tmp/test: Read-only file system
```