### PR TITLE
kubeseal: Add --fetch-cert to dump cert to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ and needs to be available wherever `kubeseal` is going to be
 used. The certificate is not secret information, although you need to
 ensure you are using the correct file.
 
-`kubeseal` will fetch the certificate from the controller at
-runtime (requires secure access to the Kubernetes API server), but can
-also be read from a local file for offline situations (eg: automated
-jobs).  The certificate is also printed to the controller log on
-startup.
+`kubeseal` will fetch the certificate from the controller at runtime
+(requires secure access to the Kubernetes API server), which is
+convenient for interactive use.  The recommended automation workflow
+is to store the certificate to local disk with `kubeseal --fetch-cert
+>mycert.pem`, and use it offline with `kubeseal --cert mycert.pem`.
+The certificate is also printed to the controller log on startup.
 
 ### Installation from source
 

--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -35,6 +35,7 @@ var (
 	controllerNs   = flag.String("controller-namespace", api.NamespaceSystem, "Namespace of sealed-secrets controller.")
 	controllerName = flag.String("controller-name", "sealed-secrets-controller", "Name of sealed-secrets controller.")
 	outputFormat   = flag.String("format", "json", "Output format for sealed secret. Either json or yaml")
+	dumpCert       = flag.Bool("fetch-cert", false, "Write certificate to stdout.  Useful for later use with --cert")
 
 	clientConfig clientcmd.ClientConfig
 )
@@ -218,6 +219,13 @@ func main() {
 		panic(err.Error())
 	}
 	defer f.Close()
+
+	if *dumpCert {
+		if _, err := io.Copy(os.Stdout, f); err != nil {
+			panic(err.Error())
+		}
+		return
+	}
 
 	pubKey, err := parseKey(f)
 	if err != nil {


### PR DESCRIPTION
This change adds a `--fetch-cert` option, which dumps the certificate
to stdout and exits.  Hopefully this makes it easier to use `--cert`
and the offline workflow.

Fixes #48