### PR TITLE
Revert change to kubeseal github release paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ script:
   - make test
   - make vet
   - make kubeseal-static
-  - EXE_NAME=$(go env GOOS)-$(go env GOARCH)/kubeseal
-  - mkdir -p $(dirname $EXE_NAME)
+  - EXE_NAME=kubeseal-$(go env GOOS)-$(go env GOARCH)
   - cp kubeseal-static $EXE_NAME
   - ./$EXE_NAME --help || test $? -eq 2
   - |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ $ release=$(curl --silent "https://api.github.com/repos/bitnami/sealed-secrets/r
 # Install client-side tool into /usr/local/bin/
 $ GOOS=$(go env GOOS)
 $ GOARCH=$(go env GOARCH)
-$ wget https://github.com/bitnami/sealed-secrets/releases/download/$release/$GOOS-$GOARCH/kubeseal
-$ sudo install -m 755 kubeseal /usr/local/bin/
+$ wget https://github.com/bitnami/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
+$ sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
 
 # Install SealedSecret TPR (for k8s < 1.7)
 $ kubectl create -f https://github.com/bitnami/sealed-secrets/releases/download/$release/sealedsecret-tpr.yaml


### PR DESCRIPTION
This reverts a small part of fb7628db56118b946244fca4d7fce2a561b91dd5

Turns out travis' github client strips subdir paths in binaries,
making that approach infeasible.