### PR TITLE
Allow setting custom label for encrypt/decrypt

### DIFF
--- a/apis/v1alpha1/sealedsecret.go
+++ b/apis/v1alpha1/sealedsecret.go
@@ -81,8 +81,8 @@ func (sl *SealedSecretList) GetListMeta() metav1.List {
 }
 
 func labelFor(o metav1.Object) ([]byte, bool) {
-	label, ok := o.GetAnnotations()[SealedSecretLabelAnnotation]
-	if ok && label != "" {
+	label := o.GetAnnotations()[SealedSecretLabelAnnotation]
+	if label != "" {
 		return []byte(label), true
 	}
 	label = fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName())

--- a/apis/v1alpha1/sealedsecret_test.go
+++ b/apis/v1alpha1/sealedsecret_test.go
@@ -42,13 +42,13 @@ func TestLabel(t *testing.T) {
 	}
 }
 
-func TestCustomLabel(t *testing.T) {
+func TestClusterWide(t *testing.T) {
 	s := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myname",
 			Namespace: "myns",
 			Annotations: map[string]string{
-				SealedSecretLabelAnnotation: "my-label",
+				SealedSecretClusterWideAnnotation: "true",
 			},
 		},
 	}
@@ -56,7 +56,7 @@ func TestCustomLabel(t *testing.T) {
 	if !c {
 		t.Errorf("Unexpected value for custom: %#v", c)
 	}
-	if string(l) != "my-label" {
+	if string(l) != "" {
 		t.Errorf("Unexpected label: %#v", l)
 	}
 }
@@ -158,7 +158,7 @@ func TestSealRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSealRoundTripWithCustomLabel(t *testing.T) {
+func TestSealRoundTripWithClusterWide(t *testing.T) {
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
@@ -176,7 +176,7 @@ func TestSealRoundTripWithCustomLabel(t *testing.T) {
 			Name:      "myname",
 			Namespace: "myns",
 			Annotations: map[string]string{
-				SealedSecretLabelAnnotation: "my-custom-label",
+				SealedSecretClusterWideAnnotation: "true",
 			},
 		},
 		Data: map[string][]byte{
@@ -199,7 +199,7 @@ func TestSealRoundTripWithCustomLabel(t *testing.T) {
 	}
 }
 
-func TestSealRoundTripWithMisMatchCustomLabel(t *testing.T) {
+func TestSealRoundTripWithMisMatchClusterWide(t *testing.T) {
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
@@ -217,7 +217,7 @@ func TestSealRoundTripWithMisMatchCustomLabel(t *testing.T) {
 			Name:      "myname",
 			Namespace: "myns",
 			Annotations: map[string]string{
-				SealedSecretLabelAnnotation: "my-custom-label",
+				SealedSecretClusterWideAnnotation: "true",
 			},
 		},
 		Data: map[string][]byte{
@@ -230,7 +230,7 @@ func TestSealRoundTripWithMisMatchCustomLabel(t *testing.T) {
 		t.Fatalf("NewSealedSecret returned error: %v", err)
 	}
 
-	ssecret.Metadata.Annotations[SealedSecretLabelAnnotation] = "mismatch"
+	ssecret.Metadata.Annotations[SealedSecretClusterWideAnnotation] = "false"
 
 	_, err = ssecret.Unseal(codecs, key)
 	if err == nil {


### PR DESCRIPTION
This would allow a secret to be used in multiple namespaces.  We spin up test environments in different generated namespaces and this allows us to reuse the same secret without having to re-seal each time by setting an annotation on the source secret.

I can add docs if you think this is useful.