### PR TITLE
Encrypt secrets individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ wanting to use `SealedSecret`s with this cluster.  The certificate is
 printed to the controller log at startup, and available via an HTTP
 GET to `/v1/cert.pem` on the controller.
 
-During encryption, the original `Secret` is JSON-encoded and
+During encryption, each value in the original `Secret` is
 symmetrically encrypted using AES-GCM with a randomly-generated
 single-use session key.  The session key is then asymmetrically
 encrypted with the controller's public key using RSA-OAEP, and the

--- a/apis/v1alpha1/sealedsecret.go
+++ b/apis/v1alpha1/sealedsecret.go
@@ -13,7 +13,6 @@ import (
 	"io"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/pkg/api/v1"
@@ -37,7 +36,7 @@ var ErrTooShort = errors.New("SealedSecret data is too short")
 
 // SealedSecretSpec is the specification of a SealedSecret
 type SealedSecretSpec struct {
-	Data []byte `json:"data"`
+	Data map[string][]byte `json:"data"`
 }
 
 // SealedSecret is the K8s representation of a "sealed Secret" - a
@@ -168,28 +167,8 @@ func hybridDecrypt(rnd io.Reader, privKey *rsa.PrivateKey, ciphertext, label []b
 // NewSealedSecret creates a new SealedSecret object wrapping the
 // provided secret.
 func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKey, secret *v1.Secret) (*SealedSecret, error) {
-	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
-	if !ok {
-		return nil, fmt.Errorf("binary can't serialize JSON")
-	}
-
 	if secret.GetNamespace() == "" {
 		return nil, fmt.Errorf("Secret must declare a namespace")
-	}
-
-	codec := codecs.EncoderForVersion(info.Serializer, v1.SchemeGroupVersion)
-	plaintext, err := runtime.Encode(codec, secret)
-	if err != nil {
-		return nil, err
-	}
-
-	// RSA-OAEP will fail to decrypt unless the same label is used
-	// during decryption.
-	label, clusterWide := labelFor(secret)
-
-	ciphertext, err := hybridEncrypt(rand.Reader, pubKey, plaintext, label)
-	if err != nil {
-		return nil, err
 	}
 
 	s := &SealedSecret{
@@ -198,8 +177,20 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 			Namespace: secret.GetNamespace(),
 		},
 		Spec: SealedSecretSpec{
-			Data: ciphertext,
+			Data: map[string][]byte{},
 		},
+	}
+
+	// RSA-OAEP will fail to decrypt unless the same label is used
+	// during decryption.
+	label, clusterWide := labelFor(secret)
+
+	for key, value := range secret.Data {
+		ciphertext, err := hybridEncrypt(rand.Reader, pubKey, value, label)
+		if err != nil {
+			return nil, err
+		}
+		s.Spec.Data[key] = ciphertext
 	}
 
 	if clusterWide {
@@ -219,15 +210,14 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKey *rs
 	// namespace/name.
 	label, _ := labelFor(smeta)
 
-	plaintext, err := hybridDecrypt(rand.Reader, privKey, s.Spec.Data, label)
-	if err != nil {
-		return nil, err
-	}
-
 	var secret v1.Secret
-	dec := codecs.UniversalDecoder(secret.GroupVersionKind().GroupVersion())
-	if err = runtime.DecodeInto(dec, plaintext, &secret); err != nil {
-		return nil, err
+	secret.Data = map[string][]byte{}
+	for key, value := range s.Spec.Data {
+		plaintext, err := hybridDecrypt(rand.Reader, privKey, value, label)
+		if err != nil {
+			return nil, err
+		}
+		secret.Data[key] = plaintext
 	}
 
 	// Ensure these are set to what we expect

--- a/apis/v1alpha1/sealedsecret_test.go
+++ b/apis/v1alpha1/sealedsecret_test.go
@@ -68,7 +68,10 @@ func TestSerialize(t *testing.T) {
 			Namespace: "myns",
 		},
 		Spec: SealedSecretSpec{
-			Data: []byte("xxx"),
+			Data: map[string][]byte{
+				"foo": []byte("secret1"),
+				"bar": []byte("secret2"),
+			},
 		},
 	}
 

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -167,7 +167,7 @@ func TestSeal(t *testing.T) {
 	if smeta.GetNamespace() != "myns" {
 		t.Errorf("Unexpected namespace: %v", smeta.GetNamespace())
 	}
-	if len(result.Spec.Data) < 100 {
+	if len(result.Spec.Data["foo"]) < 100 {
 		t.Errorf("Encrypted data is implausibly short: %v", result.Spec.Data)
 	}
 	// NB: See sealedsecret_test.go for e2e crypto test

--- a/cmd/kubeseal/main_test.go
+++ b/cmd/kubeseal/main_test.go
@@ -167,8 +167,8 @@ func TestSeal(t *testing.T) {
 	if smeta.GetNamespace() != "myns" {
 		t.Errorf("Unexpected namespace: %v", smeta.GetNamespace())
 	}
-	if len(result.Spec.Data["foo"]) < 100 {
-		t.Errorf("Encrypted data is implausibly short: %v", result.Spec.Data)
+	if len(result.Spec.EncryptedData["foo"]) < 100 {
+		t.Errorf("Encrypted data is implausibly short: %v", result.Spec.EncryptedData)
 	}
 	// NB: See sealedsecret_test.go for e2e crypto test
 }

--- a/sealedsecret-crd.jsonnet
+++ b/sealedsecret-crd.jsonnet
@@ -27,6 +27,10 @@ local crd = {
             type: "object",
             properties: {
               data: {
+                type: "string",
+                pattern: "^[^A-Za-z0-9+/=]*$", // base64
+              },
+              encryptedData: {
                 patternProperties: {
                   "^.*$": {
                     pattern: "^[^A-Za-z0-9+/=]*$", // base64

--- a/sealedsecret-crd.jsonnet
+++ b/sealedsecret-crd.jsonnet
@@ -27,8 +27,12 @@ local crd = {
             type: "object",
             properties: {
               data: {
-                type: "string",
-                pattern: "^[^A-Za-z0-9+/=]*$", // base64
+                patternProperties: {
+                  "^.*$": {
+                    pattern: "^[^A-Za-z0-9+/=]*$", // base64
+                    type: "string",
+                  },
+                },
               },
             },
           },


### PR DESCRIPTION
Resolves #63 
This is not backwards compatible. The old secrets will have to be re-encrypted.

Encrypting a secret like this:
```json
{
    "kind": "Secret",
    "apiVersion": "v1",
    "metadata": {
        "name": "mysecret2",
        "creationTimestamp": null
    },
    "data": {
        "bar": "cXdl",
        "foo": "dGhpc2lzbXlzZWNyZXQy\n"
    }
}
```

Will look like this:
```json
{
  "kind": "SealedSecret",
  "apiVersion": "bitnami.com/v1alpha1",
  "metadata": {
    "name": "mysecret2",
    "namespace": "default",
    "creationTimestamp": null
  },
  "spec": {
    "data": {
      "bar": "AgBpKIK/fq7bhbUPhYhelMksEdr8hjeUjTh6MGbp3rox/pJmZ+Zsu5vCMrvth+wHt9N2vcqSnmin1dFRqeMFRCOiMvJbpWxoCqhaXR66GtGIS8lMeCZ7t0QLp5n4JkW3UDQz7qLy5InQIe9prmKTVntYicNeap4Dtx5qw275t3jW9bLbjjFn0BXxqrlkYeK9iJC1fRPvnDtOIBTmwv5MfDdZTPI5nfj1j5ot6TnQALtzZM0iogvgcnwNXIDO90feaCkyoMaG44/EcjrsEAepBrwj8tT/QwZylaqtlK1J3NDVK03IcCx7FV92zUy2BrXyDycd0KGin6wjDqkO5u9gtQTURKmM5uMQgfwH5u7P+0ZjhU3yZQs/EvMvCCDr7voTRw4bPKZevTAEt9D12U3dDgviIgahAxVyXWUsrxQXcpzPHXiw47zWZAALh4gl+RqTwN4UMQjSvw5PwIv+PQ6Sx4T1Sirxh1N1Xby+xY+hBgZXyHtl7URTURmFvYF9NE52dzC4dURAMKgsN6p94u2uiin+rngN6Um+bSwh+d72K4aIgJaD3Fbq5L3HGXrktvesmQr8QtJGZEbVf7Z2+J9p/bDUSOQ/H08zWc5yJLCUeBo6QXnSW7hseKVNcLz+tJfWOp8xskkadOUu8OJqkUDacs5CbPHo3+nhGYttJfdaTPcPP9ZsDk3OaG4nEfco9NjoC71rWjE=",
      "foo": "AgABvIHwOTs7j+aNfqC08PypNOOmigoVhxpxNwbV8wap7VajbYyG3oqdECrWKEsad1L4w9/qdA9umX9pzVVSs+mW0BWJNRNiCbQ/ekEG/K8cEeorDmhCy252YjH1tE7nXTX/OxYTowXX45BLHQyKaKnN7lVjK24QfnSnQb4ITD1RQ7yGMuVkFnBL20JwTViImJfCoJnKfqnmMQRsDMYCBblmwBzq8LT5wdvQMwZSRGAUbKK/QU2A1BvRPUQRC6j73OI0jXQT+17HIQ9Sfpyr4oZte/JjGyozckpR2057fk8uErU3mLdH+qF2qtGx0siht2LUzxsEDs2Z752RSgw3QwAWCSlH12rIZ3WM+pMi5Cj3Q/RJgaULgwGIX58AiLbeNQcxbHWjbDgTIti/qYh3UVCATsOkM2NYa+8hloKoM0TpNMTbqXPJ38imPMdgq9LenKKBLIhkrqJSJ8TpZFKfrsjLGb1Ey+PEUBH0Z9vluJKVPrK+alc6o6hP0z0Z7EgDpIN6qmgs5BoTGshZ5WN4DjsEobBENtUL4uE+96//O06UtYJLehTAv80InhLkSib+em+V/bIS5uiKjcHXySEUNayzLyIo5s5x41OIym1qwWp4g+wDg3LRsS4fGMKECLUjN+h8FQpfqN5WTmBSwY9sk9spRkF/2nTMXU01g+agYhqmtscpKAhGs5xDM2DLI0RHkD1NsqI5//QLcAbey5VaOV0="
    }
  }
}
```
