### PR TITLE
Enable encryptedData to be omitted by setting key to null in template

### DIFF
--- a/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: sealedsecrets.bitnami.com
 spec:
   group: bitnami.com
@@ -69,7 +69,10 @@ spec:
                   data:
                     additionalProperties:
                       type: string
-                    description: Keys that should be templated using decrypted data.
+                    description: |-
+                      Keys that should be templated using decrypted data.
+                      Set a key with the same name as in `encryptedData`
+                      to `null` to omit the unsealed data from the final secret.
                     nullable: true
                     type: object
                   immutable:

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -337,15 +337,19 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 		// a real secret value.
 		// See https://github.com/bitnami-labs/sealed-secrets/issues/1607
 		for key, value := range s.Spec.Template.Data {
-			if _, exists := data[key]; !exists {
-				data[key] = value
+			if _, exists := data[key]; !exists && value != nil {
+				data[key] = *value
 			}
 		}
 
 		for key, value := range s.Spec.Template.Data {
 			var plaintext bytes.Buffer
 
-			template, err := template.New(key).Funcs(sprigFuncMap).Parse(value)
+			if value == nil {
+				delete(secret.Data, key)
+				continue
+			}
+			template, err := template.New(key).Funcs(sprigFuncMap).Parse(*value)
 			if err != nil {
 				errs = append(errs, multierror.Tag(key, err))
 				continue

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
@@ -353,6 +353,10 @@ func TestSealRoundTripWithMisMatchNamespaceWide(t *testing.T) {
 	}
 }
 
+func someStr(s string) *string {
+	return &s
+}
+
 func TestSealRoundTripTemplateData(t *testing.T) {
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -367,9 +371,9 @@ func TestSealRoundTripTemplateData(t *testing.T) {
 
 	ssecret, codecs, keys := sealSecret(t, &secret, NewSealedSecret)
 
-	ssecret.Spec.Template.Data = map[string]string{
-		"bar":           `secret {{ index . "foo" }} !`,
-		"password-json": `{{ toJson .password }}`,
+	ssecret.Spec.Template.Data = map[string]*string{
+		"bar":           someStr(`secret {{ index . "foo" }} !`),
+		"password-json": someStr(`{{ toJson .password }}`),
 	}
 
 	secret2, err := ssecret.Unseal(codecs, keys)
@@ -406,16 +410,16 @@ func TestValidateEncryptedDataIgnoresTemplate(t *testing.T) {
 	ssecret, _, keys := sealSecret(t, &secret, NewSealedSecret)
 
 	// A failing template must not turn a decryptable secret into a validation failure.
-	ssecret.Spec.Template.Data = map[string]string{
-		"probe": `{{ fail "attacker-controlled failure" }}`,
+	ssecret.Spec.Template.Data = map[string]*string{
+		"probe": someStr(`{{ fail "attacker-controlled failure" }}`),
 	}
 	if err := ssecret.ValidateEncryptedData(keys); err != nil {
 		t.Errorf("ValidateEncryptedData returned error for a decryptable secret with a failing template: %v", err)
 	}
 
 	// A template with a parse error must likewise not affect the result.
-	ssecret.Spec.Template.Data = map[string]string{
-		"probe": `{{ .password`,
+	ssecret.Spec.Template.Data = map[string]*string{
+		"probe": someStr(`{{ .password`),
 	}
 	if err := ssecret.ValidateEncryptedData(keys); err != nil {
 		t.Errorf("ValidateEncryptedData returned error for a decryptable secret with an unparseable template: %v", err)
@@ -436,9 +440,9 @@ func TestTemplateDataPlaintextReference(t *testing.T) {
 	sealed := SealedSecret{
 		Spec: SealedSecretSpec{
 			Template: SecretTemplateSpec{
-				Data: map[string]string{
-					"username":     "myUsername",
-					"settings.xml": `<server><username>{{ .username }}</username></server>`,
+				Data: map[string]*string{
+					"username":     someStr("myUsername"),
+					"settings.xml": someStr(`<server><username>{{ .username }}</username></server>`),
 				},
 			},
 		},
@@ -476,12 +480,12 @@ func TestTemplateDataMixedEncryptedAndPlaintext(t *testing.T) {
 
 	ssecret, codecs, keys := sealSecret(t, &secret, NewSealedSecret)
 
-	ssecret.Spec.Template.Data = map[string]string{
-		"username": "myUsername",
-		"settings.xml": `<server>` +
+	ssecret.Spec.Template.Data = map[string]*string{
+		"username": someStr("myUsername"),
+		"settings.xml": someStr(`<server>` +
 			`<username>{{ .username }}</username>` +
 			`<password>{{ .password }}</password>` +
-			`</server>`,
+			`</server>`),
 	}
 
 	unsealed, err := ssecret.Unseal(codecs, keys)
@@ -512,9 +516,9 @@ func TestTemplateDataEncryptedTakesPrecedenceOverPlaintext(t *testing.T) {
 
 	ssecret, codecs, keys := sealSecret(t, &secret, NewSealedSecret)
 
-	ssecret.Spec.Template.Data = map[string]string{
-		"shared":  "from-plaintext-should-be-ignored",
-		"out.txt": `{{ .shared }}`,
+	ssecret.Spec.Template.Data = map[string]*string{
+		"shared":  someStr("from-plaintext-should-be-ignored"),
+		"out.txt": someStr(`{{ .shared }}`),
 	}
 
 	unsealed, err := ssecret.Unseal(codecs, keys)
@@ -536,7 +540,7 @@ func TestTemplateWithoutEncryptedData(t *testing.T) {
 	sealed := SealedSecret{
 		Spec: SealedSecretSpec{
 			Template: SecretTemplateSpec{
-				Data: map[string]string{"foo": "bar"},
+				Data: map[string]*string{"foo": someStr("bar")},
 			},
 		},
 	}
@@ -551,6 +555,41 @@ func TestTemplateWithoutEncryptedData(t *testing.T) {
 	}
 }
 
+func TestTemplateOmitEncryptedData(t *testing.T) {
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+		},
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+			"baz": []byte("qux"),
+		},
+	}
+
+	ssecret, codecs, keys := sealSecret(t, &secret, NewSealedSecret)
+
+	sealed := SealedSecret{
+		ObjectMeta: secret.ObjectMeta,
+		Spec: SealedSecretSpec{
+			EncryptedData: ssecret.Spec.EncryptedData,
+			Template: SecretTemplateSpec{
+				ObjectMeta: secret.ObjectMeta,
+				Data:       map[string]*string{"foo": nil, "bar": someStr("qux {{ .foo }} qux")},
+			},
+		},
+	}
+
+	unsealed, err := sealed.Unseal(codecs, keys)
+	if err != nil {
+		t.Fatalf("Unseal returned error: %v", err)
+	}
+
+	if got, want := unsealed.Data, map[string][]byte{"bar": []byte("qux bar qux"), "baz": []byte("qux")}; !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %q, want: %q (input: %q)", got, want, ssecret.Spec.EncryptedData)
+	}
+}
+
 func TestSkipSetOwnerReference(t *testing.T) {
 	testCases := []struct {
 		sealedSecret          SealedSecret
@@ -561,7 +600,7 @@ func TestSkipSetOwnerReference(t *testing.T) {
 			sealedSecret: SealedSecret{
 				Spec: SealedSecretSpec{
 					Template: SecretTemplateSpec{
-						Data: map[string]string{"foo": "bar"},
+						Data: map[string]*string{"foo": someStr("bar")},
 					},
 				},
 			},
@@ -574,7 +613,7 @@ func TestSkipSetOwnerReference(t *testing.T) {
 			sealedSecret: SealedSecret{
 				Spec: SealedSecretSpec{
 					Template: SecretTemplateSpec{
-						Data: map[string]string{"foo": "bar"},
+						Data: map[string]*string{"foo": someStr("bar")},
 					},
 				},
 			},

--- a/pkg/apis/sealedsecrets/v1alpha1/types.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/types.go
@@ -59,9 +59,11 @@ type SecretTemplateSpec struct {
 	Immutable *bool `json:"immutable,omitempty" protobuf:"varint,5,opt,name=immutable"`
 
 	// Keys that should be templated using decrypted data.
+	// Set a key with the same name as in `encryptedData`
+	// to `null` to omit the unsealed data from the final secret.
 	// +optional
 	// +nullable
-	Data map[string]string `json:"data,omitempty"`
+	Data map[string]*string `json:"data,omitempty"`
 }
 
 // SealedSecretSpec is the specification of a SealedSecret.

--- a/pkg/apis/sealedsecrets/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/zz_generated.deepcopy.go
@@ -199,9 +199,17 @@ func (in *SecretTemplateSpec) DeepCopyInto(out *SecretTemplateSpec) {
 	}
 	if in.Data != nil {
 		in, out := &in.Data, &out.Data
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]*string, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			var outVal *string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(string)
+				**out = **in
+			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -3,8 +3,8 @@
 package versioned
 
 import (
-	"fmt"
-	"net/http"
+	fmt "fmt"
+	http "net/http"
 
 	bitnamiv1alpha1 "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1"
 	discovery "k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -6,6 +6,7 @@ import (
 	clientset "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned"
 	bitnamiv1alpha1 "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1"
 	fakebitnamiv1alpha1 "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -15,7 +16,7 @@ import (
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// without applying any field management, validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
 func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
@@ -29,9 +30,13 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		var opts metav1.ListOptions
+		if watchAction, ok := action.(testing.WatchActionImpl); ok {
+			opts = watchAction.ListOptions
+		}
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
-		watch, err := o.Watch(gvr, ns)
+		watch, err := o.Watch(gvr, ns, opts)
 		if err != nil {
 			return false, nil, err
 		}
@@ -56,6 +61,17 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
+}
+
+// IsWatchListSemanticsUnSupported informs the reflector that this client
+// doesn't support WatchList semantics.
+//
+// This is a synthetic method whose sole purpose is to satisfy the optional
+// interface check performed by the reflector.
+// Returning true signals that WatchList can NOT be used.
+// No additional logic is implemented here.
+func (c *Clientset) IsWatchListSemanticsUnSupported() bool {
+	return true
 }
 
 var (

--- a/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake/fake_sealedsecret.go
+++ b/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake/fake_sealedsecret.go
@@ -3,123 +3,34 @@
 package fake
 
 import (
-	"context"
-
 	v1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	sealedsecretsv1alpha1 "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeSealedSecrets implements SealedSecretInterface
-type FakeSealedSecrets struct {
+// fakeSealedSecrets implements SealedSecretInterface
+type fakeSealedSecrets struct {
+	*gentype.FakeClientWithList[*v1alpha1.SealedSecret, *v1alpha1.SealedSecretList]
 	Fake *FakeBitnamiV1alpha1
-	ns   string
 }
 
-var sealedsecretsResource = v1alpha1.SchemeGroupVersion.WithResource("sealedsecrets")
-
-var sealedsecretsKind = v1alpha1.SchemeGroupVersion.WithKind("SealedSecret")
-
-// Get takes name of the sealedSecret, and returns the corresponding sealedSecret object, and an error if there is any.
-func (c *FakeSealedSecrets) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.SealedSecret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(sealedsecretsResource, c.ns, name), &v1alpha1.SealedSecret{})
-
-	if obj == nil {
-		return nil, err
+func newFakeSealedSecrets(fake *FakeBitnamiV1alpha1, namespace string) sealedsecretsv1alpha1.SealedSecretInterface {
+	return &fakeSealedSecrets{
+		gentype.NewFakeClientWithList[*v1alpha1.SealedSecret, *v1alpha1.SealedSecretList](
+			fake.Fake,
+			namespace,
+			v1alpha1.SchemeGroupVersion.WithResource("sealedsecrets"),
+			v1alpha1.SchemeGroupVersion.WithKind("SealedSecret"),
+			func() *v1alpha1.SealedSecret { return &v1alpha1.SealedSecret{} },
+			func() *v1alpha1.SealedSecretList { return &v1alpha1.SealedSecretList{} },
+			func(dst, src *v1alpha1.SealedSecretList) { dst.ListMeta = src.ListMeta },
+			func(list *v1alpha1.SealedSecretList) []*v1alpha1.SealedSecret {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1alpha1.SealedSecretList, items []*v1alpha1.SealedSecret) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1alpha1.SealedSecret), err
-}
-
-// List takes label and field selectors, and returns the list of SealedSecrets that match those selectors.
-func (c *FakeSealedSecrets) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.SealedSecretList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(sealedsecretsResource, sealedsecretsKind, c.ns, opts), &v1alpha1.SealedSecretList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1alpha1.SealedSecretList{ListMeta: obj.(*v1alpha1.SealedSecretList).ListMeta}
-	for _, item := range obj.(*v1alpha1.SealedSecretList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested sealedSecrets.
-func (c *FakeSealedSecrets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(sealedsecretsResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a sealedSecret and creates it.  Returns the server's representation of the sealedSecret, and an error, if there is any.
-func (c *FakeSealedSecrets) Create(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.CreateOptions) (result *v1alpha1.SealedSecret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(sealedsecretsResource, c.ns, sealedSecret), &v1alpha1.SealedSecret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.SealedSecret), err
-}
-
-// Update takes the representation of a sealedSecret and updates it. Returns the server's representation of the sealedSecret, and an error, if there is any.
-func (c *FakeSealedSecrets) Update(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.UpdateOptions) (result *v1alpha1.SealedSecret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(sealedsecretsResource, c.ns, sealedSecret), &v1alpha1.SealedSecret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.SealedSecret), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeSealedSecrets) UpdateStatus(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.UpdateOptions) (*v1alpha1.SealedSecret, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(sealedsecretsResource, "status", c.ns, sealedSecret), &v1alpha1.SealedSecret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.SealedSecret), err
-}
-
-// Delete takes name of the sealedSecret and deletes it. Returns an error if one occurs.
-func (c *FakeSealedSecrets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(sealedsecretsResource, c.ns, name, opts), &v1alpha1.SealedSecret{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeSealedSecrets) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(sealedsecretsResource, c.ns, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.SealedSecretList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched sealedSecret.
-func (c *FakeSealedSecrets) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.SealedSecret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(sealedsecretsResource, c.ns, name, pt, data, subresources...), &v1alpha1.SealedSecret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.SealedSecret), err
 }

--- a/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake/fake_sealedsecrets_client.go
+++ b/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake/fake_sealedsecrets_client.go
@@ -13,7 +13,7 @@ type FakeBitnamiV1alpha1 struct {
 }
 
 func (c *FakeBitnamiV1alpha1) SealedSecrets(namespace string) v1alpha1.SealedSecretInterface {
-	return &FakeSealedSecrets{c, namespace}
+	return newFakeSealedSecrets(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/sealedsecret.go
+++ b/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/sealedsecret.go
@@ -3,15 +3,14 @@
 package v1alpha1
 
 import (
-	"context"
-	"time"
+	context "context"
 
-	v1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+	sealedsecretsv1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	scheme "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // SealedSecretsGetter has a method to return a SealedSecretInterface.
@@ -22,158 +21,34 @@ type SealedSecretsGetter interface {
 
 // SealedSecretInterface has methods to work with SealedSecret resources.
 type SealedSecretInterface interface {
-	Create(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.CreateOptions) (*v1alpha1.SealedSecret, error)
-	Update(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.UpdateOptions) (*v1alpha1.SealedSecret, error)
-	UpdateStatus(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.UpdateOptions) (*v1alpha1.SealedSecret, error)
+	Create(ctx context.Context, sealedSecret *sealedsecretsv1alpha1.SealedSecret, opts v1.CreateOptions) (*sealedsecretsv1alpha1.SealedSecret, error)
+	Update(ctx context.Context, sealedSecret *sealedsecretsv1alpha1.SealedSecret, opts v1.UpdateOptions) (*sealedsecretsv1alpha1.SealedSecret, error)
+	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+	UpdateStatus(ctx context.Context, sealedSecret *sealedsecretsv1alpha1.SealedSecret, opts v1.UpdateOptions) (*sealedsecretsv1alpha1.SealedSecret, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.SealedSecret, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1alpha1.SealedSecretList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*sealedsecretsv1alpha1.SealedSecret, error)
+	List(ctx context.Context, opts v1.ListOptions) (*sealedsecretsv1alpha1.SealedSecretList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.SealedSecret, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *sealedsecretsv1alpha1.SealedSecret, err error)
 	SealedSecretExpansion
 }
 
 // sealedSecrets implements SealedSecretInterface
 type sealedSecrets struct {
-	client rest.Interface
-	ns     string
+	*gentype.ClientWithList[*sealedsecretsv1alpha1.SealedSecret, *sealedsecretsv1alpha1.SealedSecretList]
 }
 
 // newSealedSecrets returns a SealedSecrets
 func newSealedSecrets(c *BitnamiV1alpha1Client, namespace string) *sealedSecrets {
 	return &sealedSecrets{
-		client: c.RESTClient(),
-		ns:     namespace,
+		gentype.NewClientWithList[*sealedsecretsv1alpha1.SealedSecret, *sealedsecretsv1alpha1.SealedSecretList](
+			"sealedsecrets",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			namespace,
+			func() *sealedsecretsv1alpha1.SealedSecret { return &sealedsecretsv1alpha1.SealedSecret{} },
+			func() *sealedsecretsv1alpha1.SealedSecretList { return &sealedsecretsv1alpha1.SealedSecretList{} },
+		),
 	}
-}
-
-// Get takes name of the sealedSecret, and returns the corresponding sealedSecret object, and an error if there is any.
-func (c *sealedSecrets) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.SealedSecret, err error) {
-	result = &v1alpha1.SealedSecret{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of SealedSecrets that match those selectors.
-func (c *sealedSecrets) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.SealedSecretList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1alpha1.SealedSecretList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested sealedSecrets.
-func (c *sealedSecrets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a sealedSecret and creates it.  Returns the server's representation of the sealedSecret, and an error, if there is any.
-func (c *sealedSecrets) Create(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.CreateOptions) (result *v1alpha1.SealedSecret, err error) {
-	result = &v1alpha1.SealedSecret{}
-	err = c.client.Post().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(sealedSecret).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a sealedSecret and updates it. Returns the server's representation of the sealedSecret, and an error, if there is any.
-func (c *sealedSecrets) Update(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.UpdateOptions) (result *v1alpha1.SealedSecret, err error) {
-	result = &v1alpha1.SealedSecret{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		Name(sealedSecret.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(sealedSecret).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *sealedSecrets) UpdateStatus(ctx context.Context, sealedSecret *v1alpha1.SealedSecret, opts v1.UpdateOptions) (result *v1alpha1.SealedSecret, err error) {
-	result = &v1alpha1.SealedSecret{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		Name(sealedSecret.Name).
-		SubResource("status").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(sealedSecret).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the sealedSecret and deletes it. Returns an error if one occurs.
-func (c *sealedSecrets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *sealedSecrets) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched sealedSecret.
-func (c *sealedSecrets) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.SealedSecret, err error) {
-	result = &v1alpha1.SealedSecret{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("sealedsecrets").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/sealedsecrets_client.go
+++ b/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/sealedsecrets_client.go
@@ -3,10 +3,10 @@
 package v1alpha1
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
-	"github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/scheme"
+	sealedsecretsv1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+	scheme "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -29,9 +29,7 @@ func (c *BitnamiV1alpha1Client) SealedSecrets(namespace string) SealedSecretInte
 // where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*BitnamiV1alpha1Client, error) {
 	config := *c
-	if err := setConfigDefaults(&config); err != nil {
-		return nil, err
-	}
+	setConfigDefaults(&config)
 	httpClient, err := rest.HTTPClientFor(&config)
 	if err != nil {
 		return nil, err
@@ -43,9 +41,7 @@ func NewForConfig(c *rest.Config) (*BitnamiV1alpha1Client, error) {
 // Note the http client provided takes precedence over the configured transport values.
 func NewForConfigAndClient(c *rest.Config, h *http.Client) (*BitnamiV1alpha1Client, error) {
 	config := *c
-	if err := setConfigDefaults(&config); err != nil {
-		return nil, err
-	}
+	setConfigDefaults(&config)
 	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
@@ -68,17 +64,15 @@ func New(c rest.Interface) *BitnamiV1alpha1Client {
 	return &BitnamiV1alpha1Client{c}
 }
 
-func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
+func setConfigDefaults(config *rest.Config) {
+	gv := sealedsecretsv1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
-
-	return nil
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -3,6 +3,7 @@
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -13,6 +14,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -27,6 +29,7 @@ type sharedInformerFactory struct {
 	defaultResync    time.Duration
 	customResync     map[reflect.Type]time.Duration
 	transform        cache.TransformFunc
+	informerName     *cache.InformerName
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -73,6 +76,21 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
+// WithInformerName sets the InformerName for informer identity used in metrics.
+// The InformerName must be created via cache.NewInformerName() at startup,
+// which validates global uniqueness. Each informer type will register its
+// GVR under this name.
+func WithInformerName(informerName *cache.InformerName) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informerName = informerName
+		return factory
+	}
+}
+
+func (f *sharedInformerFactory) InformerName() *cache.InformerName {
+	return f.informerName
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -81,6 +99,7 @@ func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Dur
 // NewFilteredSharedInformerFactory constructs a new instance of sharedInformerFactory.
 // Listers obtained via this SharedInformerFactory will be subject to the same filters
 // as specified here.
+//
 // Deprecated: Please use NewSharedInformerFactoryWithOptions instead
 func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync time.Duration, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync, WithNamespace(namespace), WithTweakListOptions(tweakListOptions))
@@ -106,6 +125,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -115,15 +138,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -136,9 +153,15 @@ func (f *sharedInformerFactory) Shutdown() {
 
 	// Will return immediately if there is nothing to wait for.
 	f.wg.Wait()
+	f.informerName.Release()
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -152,10 +175,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -177,7 +221,9 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	}
 
 	informer = newFunc(f.client, resyncPeriod)
-	informer.SetTransform(f.transform)
+	if f.transform != nil {
+		informer.SetTransform(f.transform)
+	}
 	f.informers[informerType] = informer
 
 	return informer
@@ -188,31 +234,51 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //
 // It is typically used like this:
 //
-//	ctx, cancel := context.Background()
+//	ctx, cancel := context.WithCancel(context.Background())
 //	defer cancel()
 //	factory := NewSharedInformerFactory(client, resyncPeriod)
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
+	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -228,7 +294,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -3,7 +3,7 @@
 package externalversions
 
 import (
-	"fmt"
+	fmt "fmt"
 
 	v1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -18,7 +18,26 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	InformerName() *cache.InformerName
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.
 type TweakListOptionsFunc func(*v1.ListOptions)
+
+// InformerOptions holds the options for creating an informer.
+type InformerOptions struct {
+	// ResyncPeriod is the resync period for this informer.
+	// If not set, defaults to 0 (no resync).
+	ResyncPeriod time.Duration
+
+	// Indexers are the indexers for this informer.
+	Indexers cache.Indexers
+
+	// InformerName is used to uniquely identify this informer for metrics.
+	// If not set, metrics will not be published for this informer.
+	// Use cache.NewInformerName() to create an InformerName at startup.
+	InformerName *cache.InformerName
+
+	// TweakListOptions is an optional function to modify the list options.
+	TweakListOptions TweakListOptionsFunc
+}

--- a/pkg/client/informers/externalversions/sealedsecrets/v1alpha1/sealedsecret.go
+++ b/pkg/client/informers/externalversions/sealedsecrets/v1alpha1/sealedsecret.go
@@ -3,15 +3,16 @@
 package v1alpha1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
-	sealedsecretsv1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+	apissealedsecretsv1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	versioned "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/bitnami/sealed-secrets/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/bitnami/sealed-secrets/pkg/client/listers/sealedsecrets/v1alpha1"
+	sealedsecretsv1alpha1 "github.com/bitnami/sealed-secrets/pkg/client/listers/sealedsecrets/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
 )
@@ -20,7 +21,7 @@ import (
 // SealedSecrets.
 type SealedSecretInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1alpha1.SealedSecretLister
+	Lister() sealedsecretsv1alpha1.SealedSecretLister
 }
 
 type sealedSecretInformer struct {
@@ -33,42 +34,67 @@ type sealedSecretInformer struct {
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewSealedSecretInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredSealedSecretInformer(client, namespace, resyncPeriod, indexers, nil)
+	return NewSealedSecretInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
 }
 
 // NewFilteredSealedSecretInformer constructs a new informer for SealedSecret type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredSealedSecretInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+	return NewSealedSecretInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewSealedSecretInformerWithOptions constructs a new informer for SealedSecret type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewSealedSecretInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	gvr := schema.GroupVersionResource{Group: "bitnami.com", Version: "v1alpha1", Resource: "sealedsecrets"}
+	identifier := options.InformerName.WithResource(gvr)
+	tweakListOptions := options.TweakListOptions
+	return cache.NewSharedIndexInformerWithOptions(
+		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
+			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
-					tweakListOptions(&options)
+					tweakListOptions(&opts)
 				}
-				return client.BitnamiV1alpha1().SealedSecrets(namespace).List(context.TODO(), options)
+				return client.BitnamiV1alpha1().SealedSecrets(namespace).List(context.Background(), opts)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(opts v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
-					tweakListOptions(&options)
+					tweakListOptions(&opts)
 				}
-				return client.BitnamiV1alpha1().SealedSecrets(namespace).Watch(context.TODO(), options)
+				return client.BitnamiV1alpha1().SealedSecrets(namespace).Watch(context.Background(), opts)
 			},
+			ListWithContextFunc: func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&opts)
+				}
+				return client.BitnamiV1alpha1().SealedSecrets(namespace).List(ctx, opts)
+			},
+			WatchFuncWithContext: func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&opts)
+				}
+				return client.BitnamiV1alpha1().SealedSecrets(namespace).Watch(ctx, opts)
+			},
+		}, client),
+		&apissealedsecretsv1alpha1.SealedSecret{},
+		cache.SharedIndexInformerOptions{
+			ResyncPeriod: options.ResyncPeriod,
+			Indexers:     options.Indexers,
+			Identifier:   identifier,
 		},
-		&sealedsecretsv1alpha1.SealedSecret{},
-		resyncPeriod,
-		indexers,
 	)
 }
 
 func (f *sealedSecretInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredSealedSecretInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewSealedSecretInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *sealedSecretInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&sealedsecretsv1alpha1.SealedSecret{}, f.defaultInformer)
+	return f.factory.InformerFor(&apissealedsecretsv1alpha1.SealedSecret{}, f.defaultInformer)
 }
 
-func (f *sealedSecretInformer) Lister() v1alpha1.SealedSecretLister {
-	return v1alpha1.NewSealedSecretLister(f.Informer().GetIndexer())
+func (f *sealedSecretInformer) Lister() sealedsecretsv1alpha1.SealedSecretLister {
+	return sealedsecretsv1alpha1.NewSealedSecretLister(f.Informer().GetIndexer())
 }

--- a/pkg/client/listers/sealedsecrets/v1alpha1/sealedsecret.go
+++ b/pkg/client/listers/sealedsecrets/v1alpha1/sealedsecret.go
@@ -3,10 +3,10 @@
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/cache"
+	sealedsecretsv1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // SealedSecretLister helps list SealedSecrets.
@@ -14,7 +14,7 @@ import (
 type SealedSecretLister interface {
 	// List lists all SealedSecrets in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.SealedSecret, err error)
+	List(selector labels.Selector) (ret []*sealedsecretsv1alpha1.SealedSecret, err error)
 	// SealedSecrets returns an object that can list and get SealedSecrets.
 	SealedSecrets(namespace string) SealedSecretNamespaceLister
 	SealedSecretListerExpansion
@@ -22,25 +22,17 @@ type SealedSecretLister interface {
 
 // sealedSecretLister implements the SealedSecretLister interface.
 type sealedSecretLister struct {
-	indexer cache.Indexer
+	listers.ResourceIndexer[*sealedsecretsv1alpha1.SealedSecret]
 }
 
 // NewSealedSecretLister returns a new SealedSecretLister.
 func NewSealedSecretLister(indexer cache.Indexer) SealedSecretLister {
-	return &sealedSecretLister{indexer: indexer}
-}
-
-// List lists all SealedSecrets in the indexer.
-func (s *sealedSecretLister) List(selector labels.Selector) (ret []*v1alpha1.SealedSecret, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.SealedSecret))
-	})
-	return ret, err
+	return &sealedSecretLister{listers.New[*sealedsecretsv1alpha1.SealedSecret](indexer, sealedsecretsv1alpha1.Resource("sealedsecret"))}
 }
 
 // SealedSecrets returns an object that can list and get SealedSecrets.
 func (s *sealedSecretLister) SealedSecrets(namespace string) SealedSecretNamespaceLister {
-	return sealedSecretNamespaceLister{indexer: s.indexer, namespace: namespace}
+	return sealedSecretNamespaceLister{listers.NewNamespaced[*sealedsecretsv1alpha1.SealedSecret](s.ResourceIndexer, namespace)}
 }
 
 // SealedSecretNamespaceLister helps list and get SealedSecrets.
@@ -48,36 +40,15 @@ func (s *sealedSecretLister) SealedSecrets(namespace string) SealedSecretNamespa
 type SealedSecretNamespaceLister interface {
 	// List lists all SealedSecrets in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.SealedSecret, err error)
+	List(selector labels.Selector) (ret []*sealedsecretsv1alpha1.SealedSecret, err error)
 	// Get retrieves the SealedSecret from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.SealedSecret, error)
+	Get(name string) (*sealedsecretsv1alpha1.SealedSecret, error)
 	SealedSecretNamespaceListerExpansion
 }
 
 // sealedSecretNamespaceLister implements the SealedSecretNamespaceLister
 // interface.
 type sealedSecretNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all SealedSecrets in the indexer for a given namespace.
-func (s sealedSecretNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.SealedSecret, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.SealedSecret))
-	})
-	return ret, err
-}
-
-// Get retrieves the SealedSecret from the indexer for a given namespace and name.
-func (s sealedSecretNamespaceLister) Get(name string) (*v1alpha1.SealedSecret, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, errors.NewNotFound(v1alpha1.Resource("sealedsecret"), name)
-	}
-	return obj.(*v1alpha1.SealedSecret), nil
+	listers.ResourceIndexer[*sealedsecretsv1alpha1.SealedSecret]
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -23,6 +23,10 @@ import (
 	ssfake "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/fake"
 )
 
+func someStr(s string) *string {
+	return &s
+}
+
 func TestIsAnnotatedToBePatched(t *testing.T) {
 	tests := []struct {
 		annotations map[string]string
@@ -445,8 +449,8 @@ func TestAttemptUnsealIgnoresTemplate(t *testing.T) {
 	}
 
 	// Attacker-controlled, always-failing template paired with the victim's real data.
-	ssecret.Spec.Template.Data = map[string]string{
-		"probe": `{{ fail "attacker-controlled failure" }}`,
+	ssecret.Spec.Template.Data = map[string]*string{
+		"probe": someStr(`{{ fail "attacker-controlled failure" }}`),
 	}
 
 	enc, err := prettyEncoder(scheme.Codecs, runtime.ContentTypeJSON, ssv1alpha1.SchemeGroupVersion)

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -381,7 +381,7 @@ func prepareController(
 		options.LabelSelector = keySelector.String()
 	}, f.WatchForSecrets)
 	sinformer := initSecretInformerFactory(clientset, namespace, tweakopts, !f.SkipRecreate)
-	ssinformer := ssinformers.NewFilteredSharedInformerFactory(ssclientset, 0, namespace, tweakopts)
+	ssinformer := ssinformers.NewSharedInformerFactoryWithOptions(ssclientset, 0, ssinformers.WithNamespace(namespace), ssinformers.WithTweakListOptions(tweakopts))
 	controller, err := NewController(clientset, ssclientset, ssinformer, sinformer, kinformer, keyRegistry, f.MaxRetries, f.KeyOrderPriority)
 	return controller, err
 }

--- a/schema-v1alpha1.yaml
+++ b/schema-v1alpha1.yaml
@@ -41,7 +41,10 @@ openAPIV3Schema:
             data:
               additionalProperties:
                 type: string
-              description: Keys that should be templated using decrypted data.
+              description: |-
+                Keys that should be templated using decrypted data.
+                Set a key with the same name as in `encryptedData`
+                to `null` to omit the unsealed data from the final secret.
               nullable: true
               type: object
             immutable:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Make `SealedSecret.spec.template.data` fields nullable. A null value indicates that the key should be omitted from the final secret.

Change is backwards compatible.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Templated Secrets can be used in cases where the set of keys is significant, i.e. extraneous keys are not acceptable.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None known.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami-labs/sealed-secrets/issues/1870

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
