### PR TITLE
kubeseal: apply --namespace when unsealing secrets without one

### DIFF
--- a/cmd/kubeseal/main.go
+++ b/cmd/kubeseal/main.go
@@ -101,7 +101,7 @@ func bindFlags(f *cliFlags, fs *flag.FlagSet) {
 	fs.BoolVar(&f.reEncrypt, "re-encrypt", false, "Re-encrypt the given sealed secret to use the latest cluster key.")
 	_ = fs.MarkDeprecated("rotate", "please use --re-encrypt instead")
 
-	fs.BoolVar(&f.unseal, "recovery-unseal", false, "Decrypt a sealed secrets file obtained from stdin, using the private key passed with --recovery-private-key. Intended to be used in disaster recovery mode.")
+	fs.BoolVar(&f.unseal, "recovery-unseal", false, "Decrypt a sealed secrets file obtained from stdin, using the private key passed with --recovery-private-key. Intended to be used in disaster recovery mode. If the sealed secret does not declare a namespace, the value of --namespace is used.")
 	fs.StringSliceVar(&f.privKeys, "recovery-private-key", nil, "Private key filename used by the --recovery-unseal command. Multiple files accepted either via comma separated list or by repetition of the flag. Either PEM encoded private keys or a backup of a json/yaml encoded k8s sealed-secret controller secret (and v1.List) are accepted. ")
 	fs.BoolVar(&f.help, "help", false, "Print this help message")
 
@@ -182,7 +182,11 @@ func runCLI(w io.Writer, cfg *config) (err error) {
 	}
 
 	if flags.unseal {
-		return kubeseal.UnsealSealedSecret(w, input, flags.privKeys, flags.outputFormat, scheme.Codecs)
+		namespace, _, err := cfg.clientConfig.Namespace()
+		if err != nil {
+			return err
+		}
+		return kubeseal.UnsealSealedSecret(w, input, flags.privKeys, flags.outputFormat, namespace, scheme.Codecs)
 	}
 	if len(flags.privKeys) != 0 && isatty.IsTerminal(os.Stderr.Fd()) {
 		fmt.Fprintf(os.Stderr, "warning: ignoring --recovery-private-key because unseal command not chosen with --recovery-unseal\n")

--- a/pkg/kubeseal/kubeseal.go
+++ b/pkg/kubeseal/kubeseal.go
@@ -603,7 +603,7 @@ func readPrivKeys(filenames []string) (map[string]*rsa.PrivateKey, error) {
 	return res, nil
 }
 
-func UnsealSealedSecret(w io.Writer, in io.Reader, privKeysFilenames []string, outputFormat string, codecs runtimeserializer.CodecFactory) error {
+func UnsealSealedSecret(w io.Writer, in io.Reader, privKeysFilenames []string, outputFormat, ns string, codecs runtimeserializer.CodecFactory) error {
 	privKeys, err := readPrivKeys(privKeysFilenames)
 	if err != nil {
 		return err
@@ -617,6 +617,9 @@ func UnsealSealedSecret(w io.Writer, in io.Reader, privKeysFilenames []string, o
 	ss, err := decodeSealedSecret(codecs, b)
 	if err != nil {
 		return err
+	}
+	if ss.GetNamespace() == "" && ss.Scope() != ssv1alpha1.ClusterWideScope {
+		ss.SetNamespace(ns)
 	}
 	sec, err := ss.Unseal(codecs, privKeys)
 	if err != nil {

--- a/pkg/kubeseal/kubeseal_test.go
+++ b/pkg/kubeseal/kubeseal_test.go
@@ -560,13 +560,14 @@ func newTestKeyPair(t *testing.T) (*rsa.PublicKey, map[string]*rsa.PrivateKey) {
 	return pubKey, privKeys
 }
 
-func TestUnseal(t *testing.T) {
+func newTestKeyPairFile(t *testing.T) (*rsa.PublicKey, string) {
+	t.Helper()
 	pubKey, privKeys := newTestKeyPair(t)
 	pkFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(pkFile.Name())
+	t.Cleanup(func() { os.RemoveAll(pkFile.Name()) })
 
 	if len(privKeys) != 1 {
 		t.Fatal("assuming only one test key-pair")
@@ -579,6 +580,12 @@ func TestUnseal(t *testing.T) {
 	}
 	pkFile.Close()
 
+	return pubKey, pkFile.Name()
+}
+
+func TestUnseal(t *testing.T) {
+	pubKey, pkFileName := newTestKeyPairFile(t)
+
 	const (
 		secretItemKey   = "foo"
 		secretItemValue = "secret1"
@@ -586,9 +593,9 @@ func TestUnseal(t *testing.T) {
 	ss := mkTestSealedSecret(t, pubKey, secretItemKey, secretItemValue)
 
 	var buf bytes.Buffer
-	privKeysList := []string{pkFile.Name()}
+	privKeysList := []string{pkFileName}
 	outputFormat := "json"
-	if err := UnsealSealedSecret(&buf, bytes.NewBuffer(ss), privKeysList, outputFormat, scheme.Codecs); err != nil {
+	if err := UnsealSealedSecret(&buf, bytes.NewBuffer(ss), privKeysList, outputFormat, "", scheme.Codecs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -600,6 +607,59 @@ func TestUnseal(t *testing.T) {
 	for _, secret := range secret {
 		if got, want := string(secret.Data[secretItemKey]), secretItemValue; got != want {
 			t.Fatalf("got: %q, want: %q", got, want)
+		}
+	}
+}
+
+func TestUnsealNamespaceFromFlag(t *testing.T) {
+	pubKey, pkFileName := newTestKeyPairFile(t)
+
+	const (
+		secretItemKey   = "foo"
+		secretItemValue = "secret1"
+		namespace       = "testns"
+	)
+	// Seal with the "testns" namespace (strict scope binds the label to it),
+	// then strip the namespace from the serialized SealedSecret so it mimics a
+	// file that doesn't declare one.
+	sealed := mkTestSealedSecret(t, pubKey, secretItemKey, secretItemValue, withSecretNamespace(namespace))
+	decoded, err := decodeSealedSecret(scheme.Codecs, sealed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded.SetNamespace("")
+	prettyEnc, err := prettyEncoder(scheme.Codecs, runtime.ContentTypeJSON, ssv1alpha1.SchemeGroupVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss, err := runtime.Encode(prettyEnc, decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	privKeysList := []string{pkFileName}
+	outputFormat := "json"
+
+	if err := UnsealSealedSecret(&buf, bytes.NewBuffer(ss), privKeysList, outputFormat, "", scheme.Codecs); err == nil {
+		t.Fatal("expected error unsealing without a namespace")
+	}
+
+	buf.Reset()
+	if err := UnsealSealedSecret(&buf, bytes.NewBuffer(ss), privKeysList, outputFormat, namespace, scheme.Codecs); err != nil {
+		t.Fatal(err)
+	}
+
+	secrets, err := readSecrets(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range secrets {
+		if got, want := string(secret.Data[secretItemKey]), secretItemValue; got != want {
+			t.Fatalf("got: %q, want: %q", got, want)
+		}
+		if got, want := secret.GetNamespace(), namespace; got != want {
+			t.Fatalf("namespace got: %q, want: %q", got, want)
 		}
 	}
 }
@@ -649,7 +709,7 @@ func TestUnsealList(t *testing.T) {
 	var buf bytes.Buffer
 	privKeysList := []string{pkFile.Name()}
 	outputFormat := "json"
-	if err := UnsealSealedSecret(&buf, bytes.NewBuffer(ss), privKeysList, outputFormat, scheme.Codecs); err != nil {
+	if err := UnsealSealedSecret(&buf, bytes.NewBuffer(ss), privKeysList, outputFormat, "", scheme.Codecs); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

With --recovery-unseal, a sealed secret file that doesn't declare a namespace can now be decrypted by supplying --namespace. The flag value is used to rebuild the encryption label, so users no longer have to edit the file to add a namespace before recovering it.

**Benefits**

This is helpful because the output of `helm template` does not include a namespace by default, so being able to pass --namespace avoids having to edit the rendered manifests before recovery.

**Possible drawbacks**

It could be that the user specifies a wrong namespace or forgets to use this parameter altogether, but thats not worse than before.

**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
