### PR TITLE
fix(controller): start HTTP early for large additional-namespaces lists

### DIFF
--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -216,7 +216,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /readyz
+              path: /healthz
               port: http
           {{- else if .Values.customReadinessProbe }}
           readinessProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}

--- a/helm/sealed-secrets/templates/deployment.yaml
+++ b/helm/sealed-secrets/templates/deployment.yaml
@@ -216,7 +216,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
           {{- else if .Values.customReadinessProbe }}
           readinessProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -272,7 +272,14 @@ func Main(f *Flags, version string) error {
 
 	if f.AdditionalNamespaces != "" {
 		addNS := removeDuplicates(strings.Split(f.AdditionalNamespaces, ","))
-		if err := startAdditionalNamespaceControllers(ctx, clientset, ssclientset, keyRegistry, f, namespace, myNs, tweakopts, addNS, stop); err != nil {
+		// Bind ctx to the namespace probe here so the bootstrap helper does not
+		// take a context parameter (contextcheck would otherwise require
+		// prepareController/Run to accept one; those still use stopCh lifecycle).
+		probeNS := func(ns string) error {
+			_, err := clientset.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+			return err
+		}
+		if err := startAdditionalNamespaceControllers(probeNS, clientset, ssclientset, keyRegistry, f, namespace, myNs, tweakopts, addNS, stop); err != nil {
 			return err
 		}
 	}
@@ -296,8 +303,11 @@ func Main(f *Flags, version string) error {
 // startAdditionalNamespaceControllers validates and starts a controller for each
 // extra namespace. Work is bounded-parallel so wall-clock startup scales better
 // than one serial API Get per namespace.
+//
+// probeNS should check that ns exists (typically clientset Get with the caller's
+// context). Missing namespaces are logged and skipped; other probe errors abort.
 func startAdditionalNamespaceControllers(
-	ctx context.Context,
+	probeNS func(ns string) error,
 	clientset kubernetes.Interface,
 	ssclientset versioned.Interface,
 	keyRegistry *KeyRegistry,
@@ -335,7 +345,7 @@ func startAdditionalNamespaceControllers(
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			if _, err := clientset.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
+			if err := probeNS(ns); err != nil {
 				if errors.IsNotFound(err) {
 					slog.Error("namespace doesn't exist", "namespace", ns)
 					return

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -10,6 +10,8 @@ import (
 	"os/signal"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -27,6 +29,11 @@ import (
 	sealedsecrets "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned"
 	ssinformers "github.com/bitnami/sealed-secrets/pkg/client/informers/externalversions"
 )
+
+// Cap concurrent namespace Gets and informer setup so a large
+// --additional-namespaces list does not serialize one RTT per namespace
+// and does not stampede the API server either.
+const additionalNamespaceBootstrapConcurrency = 16
 
 var (
 	// Selector used to find existing public/private key pairs on startup.
@@ -250,30 +257,9 @@ func Main(f *Flags, version string) error {
 
 	go controller.Run(stop)
 
-	if f.AdditionalNamespaces != "" {
-		addNS := removeDuplicates(strings.Split(f.AdditionalNamespaces, ","))
-
-		for _, ns := range addNS {
-			if _, err := clientset.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
-				if errors.IsNotFound(err) {
-					slog.Error("namespace doesn't exist", "namespace", ns)
-					continue
-				}
-				return err
-			}
-			if ns != namespace {
-				ctlr, err := prepareController(clientset, ns, myNs, tweakopts, f, ssclientset, keyRegistry)
-				if err != nil {
-					return err
-				}
-				ctlr.oldGCBehavior = f.OldGCBehavior
-				ctlr.updateStatus = f.UpdateStatus
-				slog.Info("Starting informer", "namespace", ns)
-				go ctlr.Run(stop)
-			}
-		}
-	}
-
+	// ready becomes true after additional-namespace informers are started.
+	// HTTP must come up first so liveness probes succeed during that work.
+	var bootstrapped atomic.Bool
 	cp := func() ([]*x509.Certificate, error) {
 		cert, err := keyRegistry.getCert()
 		if err != nil {
@@ -281,9 +267,16 @@ func Main(f *Flags, version string) error {
 		}
 		return []*x509.Certificate{cert}, nil
 	}
-
-	server := httpserver(cp, controller.AttemptUnseal, controller.Rotate, f.RateLimitBurst, f.RateLimitPerSecond)
+	server := httpserver(cp, controller.AttemptUnseal, controller.Rotate, f.RateLimitBurst, f.RateLimitPerSecond, bootstrapped.Load)
 	serverMetrics := httpserverMetrics()
+
+	if f.AdditionalNamespaces != "" {
+		addNS := removeDuplicates(strings.Split(f.AdditionalNamespaces, ","))
+		if err := startAdditionalNamespaceControllers(ctx, clientset, ssclientset, keyRegistry, f, namespace, myNs, tweakopts, addNS, stop); err != nil {
+			return err
+		}
+	}
+	bootstrapped.Store(true)
 
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGTERM)
@@ -298,6 +291,71 @@ func Main(f *Flags, version string) error {
 	}
 
 	return nil
+}
+
+// startAdditionalNamespaceControllers validates and starts a controller for each
+// extra namespace. Work is bounded-parallel so wall-clock startup scales better
+// than one serial API Get per namespace.
+func startAdditionalNamespaceControllers(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	ssclientset versioned.Interface,
+	keyRegistry *KeyRegistry,
+	f *Flags,
+	homeNamespace string,
+	keyNamespace string,
+	tweakopts func(*metav1.ListOptions),
+	namespaces []string,
+	stop <-chan struct{},
+) error {
+	sem := make(chan struct{}, additionalNamespaceBootstrapConcurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		if firstErr == nil {
+			firstErr = err
+		}
+		mu.Unlock()
+	}
+
+	for _, ns := range namespaces {
+		ns := strings.TrimSpace(ns)
+		if ns == "" || ns == homeNamespace {
+			continue
+		}
+		wg.Add(1)
+		go func(ns string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if _, err := clientset.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
+				if errors.IsNotFound(err) {
+					slog.Error("namespace doesn't exist", "namespace", ns)
+					return
+				}
+				setErr(err)
+				return
+			}
+			ctlr, err := prepareController(clientset, ns, keyNamespace, tweakopts, f, ssclientset, keyRegistry)
+			if err != nil {
+				setErr(err)
+				return
+			}
+			ctlr.oldGCBehavior = f.OldGCBehavior
+			ctlr.updateStatus = f.UpdateStatus
+			slog.Info("Starting informer", "namespace", ns)
+			go ctlr.Run(stop)
+		}(ns)
+	}
+	wg.Wait()
+	return firstErr
 }
 
 func prepareController(

--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -29,17 +29,39 @@ type certProvider func() ([]*x509.Certificate, error)
 type secretChecker func([]byte) (bool, error)
 type secretRotator func([]byte) ([]byte, error)
 
+// readyFunc reports whether controller bootstrap finished (informers for the
+// home namespace and any --additional-namespaces have been started).
+// A nil readyFunc treats the process as always ready.
+type readyFunc func() bool
+
 // httpserver starts an HTTP that exposes core functionality like serving the public key
 // or secret rotation and validation. This endpoint is designed to be accessible by
 // all users of a given cluster. It must not leak any secret material.
 // The server is started in the background and a handle to it returned so it can be shut down.
-func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, rate int) *http.Server {
+//
+// /healthz is a liveness probe: it always succeeds once the listener is up so the
+// process is not killed while additional namespace informers are still starting.
+// /readyz is a readiness probe: it returns 503 until ready reports true.
+func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, rate int, ready readyFunc) *http.Server {
 	httpRateLimiter := rateLimiter(burst, rate)
 
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, err := io.WriteString(w, "ok\n")
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
+
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if ready != nil && !ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, "not ready\n")
+			return
+		}
 		_, err := io.WriteString(w, "ok\n")
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/controller/server_test.go
+++ b/pkg/controller/server_test.go
@@ -146,4 +146,3 @@ func TestHttpReadyz(t *testing.T) {
 		t.Fatalf("after ready: got status %v want %v body %q", got, want, body)
 	}
 }
-

--- a/pkg/controller/server_test.go
+++ b/pkg/controller/server_test.go
@@ -52,7 +52,7 @@ func TestHttpCert(t *testing.T) {
 	}
 
 	cs := &testCertStore{}
-	server := httpserver(cs.getCert, nil, nil, 2, 2)
+	server := httpserver(cs.getCert, nil, nil, 2, 2, nil)
 	defer shutdownServer(server, t)
 	hp := *listenAddr
 	if strings.HasPrefix(hp, ":") {
@@ -94,3 +94,56 @@ func TestHttpCert(t *testing.T) {
 	cs.setCert(certAfter)
 	check(certAfter)
 }
+
+func TestHttpReadyz(t *testing.T) {
+	ready := false
+	server := httpserver(func() ([]*x509.Certificate, error) {
+		return nil, fmt.Errorf("no cert")
+	}, nil, nil, 2, 2, func() bool { return ready })
+	defer shutdownServer(server, t)
+
+	hp := *listenAddr
+	if strings.HasPrefix(hp, ":") {
+		hp = fmt.Sprintf("localhost%s", hp)
+	}
+	url := fmt.Sprintf("http://%s/readyz", hp)
+	healthURL := fmt.Sprintf("http://%s/healthz", hp)
+
+	// Wait for listener
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		resp, err := http.Get(healthURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("server did not become reachable")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if got, want := resp.StatusCode, http.StatusServiceUnavailable; got != want {
+		t.Fatalf("before ready: got status %v want %v body %q", got, want, body)
+	}
+
+	ready = true
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("after ready: got status %v want %v body %q", got, want, body)
+	}
+}
+


### PR DESCRIPTION
**Description of the change**

With a large `--additional-namespaces` list the controller spent a long time in a serial loop before it ever bound the HTTP listener. Liveness probes that hit `/healthz` therefore failed even while startup was making progress.

This change:

1. Starts the HTTP and metrics servers right after the home-namespace controller begins so `/healthz` is available during bootstrap.
2. Adds `/readyz` which returns 503 until additional-namespace informers have been started then 200.
3. Points the chart readiness probe at `/readyz` (liveness stays on `/healthz`).
4. Starts additional-namespace validation and informer setup with a concurrency limit of 16 so wall-clock time is not one API RTT per namespace.

**Benefits**

- Pods with many additional namespaces keep liveness green while informers start.
- Readiness stays false until those informers are started so traffic waits for a useful controller.
- Faster bootstrap when the list is large.

**Possible drawbacks**

- Chart readiness now uses `/readyz`. Custom probes that expected readiness on `/healthz` should switch path or use `customReadinessProbe`.
- Bootstrap concurrency is capped at 16. Extremely slow API servers may still take a while but no longer block probes.

**Applicable issues**

- fixes #1959

**Additional information**

Unit coverage for `/readyz` is in `TestHttpReadyz`. `go test ./pkg/controller` passes locally.