### PR TITLE
fix: stop /v1/verify from acting as a decryption oracle

### DIFF
--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -262,6 +262,36 @@ func NewSealedSecret(codecs runtimeserializer.CodecFactory, pubKey *rsa.PublicKe
 	return s, nil
 }
 
+// ValidateEncryptedData checks decryptability without rendering spec.template.data.
+func (s *SealedSecret) ValidateEncryptedData(privKeys map[string]*rsa.PrivateKey) error {
+	label := labelFor(s.GetObjectMeta())
+
+	if s.Spec.Data == nil {
+		var errs []error
+		for key, value := range s.Spec.EncryptedData {
+			valueBytes, err := base64.StdEncoding.DecodeString(value)
+			if err != nil {
+				errs = append(errs, multierror.Tag(key, err))
+				continue
+			}
+			if _, err := crypto.HybridDecrypt(rand.Reader, privKeys, valueBytes, label); err != nil {
+				errs = append(errs, multierror.Tag(key, err))
+			}
+		}
+		if errs != nil {
+			return multierror.Format(errors.Join(multierror.Uniq(errs)...), multierror.InlineFormatter)
+		}
+		return nil
+	} else if AcceptDeprecatedV1Data { // Support decrypting old secrets for backward compatibility
+		if len(s.Spec.EncryptedData) > 0 {
+			return fmt.Errorf("cannot use the field 'encryptedData' and the deprecated field 'data' at the same time")
+		}
+		_, err := crypto.HybridDecrypt(rand.Reader, privKeys, s.Spec.Data, label)
+		return err
+	}
+	return fmt.Errorf("using deprecated 'data' field, use 'encryptedData' or flip the feature flag")
+}
+
 // Unseal decrypts and returns the embedded v1.Secret.
 func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys map[string]*rsa.PrivateKey) (*v1.Secret, error) {
 	boolTrue := true

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
@@ -391,6 +391,43 @@ func TestSealRoundTripTemplateData(t *testing.T) {
 	}
 }
 
+// TestValidateEncryptedDataIgnoresTemplate ensures template execution can't affect decryptability checks.
+func TestValidateEncryptedDataIgnoresTemplate(t *testing.T) {
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+		},
+		Data: map[string][]byte{
+			"password": []byte("hunter2"),
+		},
+	}
+
+	ssecret, _, keys := sealSecret(t, &secret, NewSealedSecret)
+
+	// A failing template must not turn a decryptable secret into a validation failure.
+	ssecret.Spec.Template.Data = map[string]string{
+		"probe": `{{ fail "attacker-controlled failure" }}`,
+	}
+	if err := ssecret.ValidateEncryptedData(keys); err != nil {
+		t.Errorf("ValidateEncryptedData returned error for a decryptable secret with a failing template: %v", err)
+	}
+
+	// A template with a parse error must likewise not affect the result.
+	ssecret.Spec.Template.Data = map[string]string{
+		"probe": `{{ .password`,
+	}
+	if err := ssecret.ValidateEncryptedData(keys); err != nil {
+		t.Errorf("ValidateEncryptedData returned error for a decryptable secret with an unparseable template: %v", err)
+	}
+
+	// Sanity check: genuinely undecryptable data must still fail.
+	_, otherKeys := generateTestKey(t, testRand(), 2048)
+	if err := ssecret.ValidateEncryptedData(otherKeys); err == nil {
+		t.Errorf("ValidateEncryptedData did not return an error for encryptedData undecryptable with the given keys")
+	}
+}
+
 // TestTemplateDataPlaintextReference verifies that plaintext keys defined
 // in spec.template.data can be referenced from sibling templates as
 // {{ .key }} variables. Regression test for

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -534,7 +534,7 @@ func formatImmutableError(key string) string {
 	return fmt.Sprintf("Error updating %s: the target Secret is immutable. Once a Secret is marked as immutable, it is not possible to revert this change nor to mutate the contents of the data field. You can only delete and recreate the Secret.", key)
 }
 
-// AttemptUnseal tries to unseal a secret.
+// AttemptUnseal checks whether a secret is decryptable, without rendering spec.template.data.
 func (c *Controller) AttemptUnseal(content []byte) (bool, error) {
 	if err := multidocyaml.EnsureNotMultiDoc(content); err != nil {
 		return false, err
@@ -547,7 +547,7 @@ func (c *Controller) AttemptUnseal(content []byte) (bool, error) {
 
 	switch s := object.(type) {
 	case *ssv1alpha1.SealedSecret:
-		if _, err := c.attemptUnseal(s); err != nil {
+		if err := s.ValidateEncryptedData(c.keyRegistry.privateKeys()); err != nil {
 			return false, nil
 		}
 		return true, nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -398,3 +398,71 @@ func TestRotateKeepScope(t *testing.T) {
 		t.Fatalf("Scope from the original and the rotate sealed secret do not match")
 	}
 }
+
+// TestAttemptUnsealIgnoresTemplate is a regression test for the /v1/verify decryption oracle.
+func TestAttemptUnsealIgnoresTemplate(t *testing.T) {
+	ns := "some-namespace"
+	keyNs := "some-key-namespace"
+	var tweakopts func(*metav1.ListOptions)
+	clientset := fake.NewClientset()
+	ssc := ssfake.NewSimpleClientset()
+	keyRegistry := testKeyRegister(t, context.Background(), clientset, ns)
+
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err := keyRegistry.generateKey(context.Background(), validFor, cn, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controller, err := prepareController(clientset, ns, keyNs, tweakopts, &Flags{SkipRecreate: false}, ssc, keyRegistry)
+	if err != nil {
+		t.Fatalf("err %v want %v", err, nil)
+	}
+
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ss",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"password": []byte("hunter2"),
+		},
+	}
+
+	cert, err := controller.keyRegistry.getCert()
+	if err != nil {
+		t.Fatalf("error getting certificate: %v", err)
+	}
+
+	ssecret, err := ssv1alpha1.NewSealedSecret(scheme.Codecs, cert.PublicKey.(*rsa.PublicKey), secret)
+	if err != nil {
+		t.Fatalf("error creating sealed secrets: %v", err)
+	}
+
+	// Attacker-controlled, always-failing template paired with the victim's real data.
+	ssecret.Spec.Template.Data = map[string]string{
+		"probe": `{{ fail "attacker-controlled failure" }}`,
+	}
+
+	enc, err := prettyEncoder(scheme.Codecs, runtime.ContentTypeJSON, ssv1alpha1.SchemeGroupVersion)
+	if err != nil {
+		t.Fatalf("unexpected pretty encoding: %v", err)
+	}
+	data, err := runtime.Encode(enc, ssecret)
+	if err != nil {
+		t.Fatalf("unexpected encoding the sealed secret: %v", err)
+	}
+
+	valid, err := controller.AttemptUnseal(data)
+	if err != nil {
+		t.Fatalf("AttemptUnseal returned error: %v", err)
+	}
+	if !valid {
+		t.Errorf("AttemptUnseal reported a decryptable secret as invalid because of an unrelated template failure")
+	}
+}


### PR DESCRIPTION
spec.template.data isn't covered by the AEAD label, so /v1/verify's full Unseal() (including template execution) let an attacker pair a victim's real metadata/encryptedData with a crafted template and leak plaintext one bit per request via the 200/409 response. AttemptUnseal now uses a new ValidateEncryptedData() that only checks decryptability and never renders templates.