### PR TITLE
test(controller): fix flaky TestReadKey RSA key comparison

### DIFF
--- a/pkg/controller/keys_test.go
+++ b/pkg/controller/keys_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"io"
 	mathrand "math/rand"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -65,11 +64,15 @@ func TestReadKey(t *testing.T) {
 		t.Errorf("readKey() failed with: %v", err)
 	}
 
-	if !reflect.DeepEqual(key, key2) {
+	// Use crypto value equality, not reflect.DeepEqual: rsa.PrivateKey embeds
+	// PrecomputedValues with unexported sync/once state that differs between a
+	// freshly generated key and one re-parsed from PEM, which made this test
+	// flaky under CI (see #1903).
+	if !key.Equal(key2) {
 		t.Errorf("Extracted key != original key")
 	}
 
-	if !reflect.DeepEqual(cert, cert2[0]) {
+	if len(cert2) == 0 || !cert.Equal(cert2[0]) {
 		t.Errorf("Extracted cert != original cert")
 	}
 }


### PR DESCRIPTION
**Description of the change**

`TestReadKey` compared generated and PEM-round-tripped `*rsa.PrivateKey` / `*x509.Certificate` values with `reflect.DeepEqual`. That is incorrect for RSA keys: `PrivateKey` embeds `PrecomputedValues` with unexported state (e.g. sync/once) that is not part of the cryptographic material and can differ after parse, so the assertion failed intermittently on CI with `Extracted key != original key`.

Switch the assertions to `key.Equal` and `cert.Equal`, which compare cryptographic value equality and ignore precomputation metadata. Also guard against an empty cert slice before indexing.

**Benefits**

- Removes a known flake of `TestReadKey` on GitHub Actions runners (reproduced in CI logs for unrelated PRs as well as #1896).
- Uses the APIs intended for key/cert equality instead of structural reflection.

**Possible drawbacks**

None expected. Test-only change; production `readKey` behavior is unchanged.

**Applicable issues**

- fixes #1903

**Additional information**

- Root cause confirmed from CI: `keys_test.go: Extracted key != original key` (not a Go toolchain bump issue; #1897 proposed upgrading Go instead).
- `go test ./pkg/controller/ -run TestReadKey -count=50` and full `go test ./pkg/controller/` pass locally.