### PR TITLE
fix(controller): remove redundant scheme registration from NewController

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -30,7 +30,6 @@ import (
 
 	ssv1alpha1 "github.com/bitnami/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	ssclientset "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned"
-	ssscheme "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/scheme"
 	ssv1alpha1client "github.com/bitnami/sealed-secrets/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1"
 	ssinformer "github.com/bitnami/sealed-secrets/pkg/client/informers/externalversions"
 	"github.com/bitnami/sealed-secrets/pkg/multidocyaml"
@@ -89,7 +88,6 @@ func NewController(
 ) (*Controller, error) {
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 
-	utilruntime.Must(ssscheme.AddToScheme(scheme.Scheme))
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(func(format string, args ...interface{}) {
 		// Must use Sprintf to ensure slog doesn't interpret args... as key-value pairs

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -544,5 +545,54 @@ func TestRotateIgnoresTemplate(t *testing.T) {
 	}
 	if _, err := controller.Rotate(data2); err != nil {
 		t.Errorf("Rotate must not turn template execution into a decryption oracle, got error: %v", err)
+	}
+}
+
+// prepareController is called once per namespace from parallel goroutines when
+// --additional-namespaces is set, so it must be safe to call concurrently.
+// Regression test for #2045.
+func TestPrepareControllerConcurrently(t *testing.T) {
+	ns := "some-namespace"
+	keyNs := "some-key-namespace"
+	var tweakopts func(*metav1.ListOptions)
+	clientset := fake.NewClientset()
+	ssc := ssfake.NewSimpleClientset()
+	keyRegistry := testKeyRegister(t, context.Background(), clientset, ns)
+
+	const goroutines = 64
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := prepareController(clientset, ns, keyNs, tweakopts, &Flags{}, ssc, keyRegistry); err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("prepareController failed under concurrency: %v", err)
+	}
+}
+
+// The controller's decoders (scheme.Codecs.UniversalDecoder) rely on the
+// SealedSecret types being present in the global scheme. That registration comes
+// from the v1alpha1 package init(), which is why NewController does not need to
+// repeat it. Guards that invariant.
+func TestSealedSecretTypesAreRegisteredGlobally(t *testing.T) {
+	for _, kind := range []string{"SealedSecret", "SealedSecretList"} {
+		if !scheme.Scheme.Recognizes(ssv1alpha1.SchemeGroupVersion.WithKind(kind)) {
+			t.Fatalf("%s is not registered in the global scheme", kind)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2045.

`NewController` registered the SealedSecret types into client-go's global `scheme.Scheme` on every call:

```go
utilruntime.Must(ssscheme.AddToScheme(scheme.Scheme))
```

That registration has already happened by then. `ssscheme.AddToScheme` is a `SchemeBuilder` whose only member is `v1alpha1.AddToScheme` (`pkg/client/clientset/versioned/scheme/register.go:17-18`), and the v1alpha1 package's own `init()` runs exactly that against `scheme.Scheme` (`pkg/apis/sealedsecrets/v1alpha1/register.go:24`). `controller.go` imports that package directly, so the `init()` has run before any controller is built.

The redundancy was harmless while startup was serial. #2018 made the additional-namespace bootstrap parallel (`pkg/controller/main.go:321-343`, concurrency 16), so `prepareController` — and through it `NewController` — now runs from many goroutines at once. `runtime.Scheme.AddKnownTypes` writes the scheme's internal maps; identical values still count as concurrent map writes, so the process aborts. A single namespace only ever calls it once, which matches default deployments being unaffected.

The fix is to drop the call and its now-unused import. `utilruntime` (used at lines 267/280/312/320) and `scheme` (99/543/563/585/604) both stay.

## Tests

- `TestPrepareControllerConcurrently` — builds controllers from 64 goroutines, mirroring the parallel bootstrap.
- `TestSealedSecretTypesAreRegisteredGlobally` — asserts the registration that `scheme.Codecs.UniversalDecoder` depends on still happens without the removed call, so the deletion cannot silently break decoding.

Measured on linux/amd64, Go 1.27.1, `go test -count=1 -run TestPrepareControllerConcurrently ./pkg/controller/...`:

| | Result |
|---|---|
| Without the fix | **5 of 5 runs fail** with `fatal error: concurrent map writes` |
| With the fix | **5 of 5 runs pass** |

Full package: `go test ./pkg/controller/...` passes (9.8s), `go vet` and `gofmt` clean.

At 16 goroutines the crash only reproduced in 2 of 3 runs, so the test uses 64 to make the failure reliable on unpatched code. It is deterministic in the direction that matters for CI — green on the fixed tree.

## One unrelated data race, noted but not fixed here

While validating under `-race` I hit a second, pre-existing race on the same path, independent of this bug: `NewController` assigns the package-level `maxRetries` (`pkg/controller/controller.go:122` before this change), so every parallel bootstrap goroutine writes one shared global that `processNextItem` reads at line 313. All callers currently write the same flag-derived value, so it does not crash — `go test -race` reports it, plain `go test` does not, and `make test` does not use `-race`.

I have deliberately left it out to keep this PR to the reported crash. Happy to send it as a follow-up if you'd like it fixed — the obvious shape is moving `maxRetries` onto the `Controller` struct.
