### PR TITLE
[Security] Stop /v1/rotate from acting as a decryption oracle

### DIFF
--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_expansion.go
@@ -292,8 +292,17 @@ func (s *SealedSecret) ValidateEncryptedData(privKeys map[string]*rsa.PrivateKey
 	return fmt.Errorf("using deprecated 'data' field, use 'encryptedData' or flip the feature flag")
 }
 
-// Unseal decrypts and returns the embedded v1.Secret.
+// Unseal decrypts and returns the embedded v1.Secret, rendering spec.template.data as a Go template.
 func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys map[string]*rsa.PrivateKey) (*v1.Secret, error) {
+	return s.unseal(codecs, privKeys, true)
+}
+
+// UnsealWithoutTemplate is like Unseal but skips rendering spec.template.data, since it's not authenticated and could be used as a decryption oracle.
+func (s *SealedSecret) UnsealWithoutTemplate(codecs runtimeserializer.CodecFactory, privKeys map[string]*rsa.PrivateKey) (*v1.Secret, error) {
+	return s.unseal(codecs, privKeys, false)
+}
+
+func (s *SealedSecret) unseal(codecs runtimeserializer.CodecFactory, privKeys map[string]*rsa.PrivateKey, renderTemplate bool) (*v1.Secret, error) {
 	boolTrue := true
 	smeta := s.GetObjectMeta()
 
@@ -328,41 +337,43 @@ func (s *SealedSecret) Unseal(codecs runtimeserializer.CodecFactory, privKeys ma
 			data[key] = string(plaintext)
 		}
 
-		// Expose raw plaintext values from spec.template.data in the
-		// template rendering context, so that templates defined in
-		// spec.template.data can reference sibling plaintext keys as
-		// {{ .key }} variables (e.g. {{ .username }} alongside an
-		// encrypted password). Encrypted values take precedence on key
-		// collision so adding a plaintext key can never silently shadow
-		// a real secret value.
-		// See https://github.com/bitnami-labs/sealed-secrets/issues/1607
-		for key, value := range s.Spec.Template.Data {
-			if _, exists := data[key]; !exists && value != nil {
-				data[key] = *value
+		if renderTemplate {
+			// Expose raw plaintext values from spec.template.data in the
+			// template rendering context, so that templates defined in
+			// spec.template.data can reference sibling plaintext keys as
+			// {{ .key }} variables (e.g. {{ .username }} alongside an
+			// encrypted password). Encrypted values take precedence on key
+			// collision so adding a plaintext key can never silently shadow
+			// a real secret value.
+			// See https://github.com/bitnami-labs/sealed-secrets/issues/1607
+			for key, value := range s.Spec.Template.Data {
+				if _, exists := data[key]; !exists && value != nil {
+					data[key] = *value
+				}
 			}
-		}
 
-		for key, value := range s.Spec.Template.Data {
-			var plaintext bytes.Buffer
+			for key, value := range s.Spec.Template.Data {
+				var plaintext bytes.Buffer
 
-			if value == nil {
-				delete(secret.Data, key)
-				continue
-			}
-			template, err := template.New(key).Funcs(sprigFuncMap).Parse(*value)
-			if err != nil {
-				errs = append(errs, multierror.Tag(key, err))
-				continue
-			}
-			err = template.Execute(&plaintext, data)
-			if err != nil {
-				errs = append(errs, multierror.Tag(key, err))
-			}
-			// Do not overwrite a key that was already populated from
-			// encryptedData; encrypted values take precedence in the
-			// output Secret as well as in the template rendering context.
-			if _, fromEncrypted := s.Spec.EncryptedData[key]; !fromEncrypted {
-				secret.Data[key] = plaintext.Bytes()
+				if value == nil {
+					delete(secret.Data, key)
+					continue
+				}
+				template, err := template.New(key).Funcs(sprigFuncMap).Parse(*value)
+				if err != nil {
+					errs = append(errs, multierror.Tag(key, err))
+					continue
+				}
+				err = template.Execute(&plaintext, data)
+				if err != nil {
+					errs = append(errs, multierror.Tag(key, err))
+				}
+				// Do not overwrite a key that was already populated from
+				// encryptedData; encrypted values take precedence in the
+				// output Secret as well as in the template rendering context.
+				if _, fromEncrypted := s.Spec.EncryptedData[key]; !fromEncrypted {
+					secret.Data[key] = plaintext.Bytes()
+				}
 			}
 		}
 

--- a/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
+++ b/pkg/apis/sealedsecrets/v1alpha1/sealedsecret_test.go
@@ -432,6 +432,43 @@ func TestValidateEncryptedDataIgnoresTemplate(t *testing.T) {
 	}
 }
 
+// TestUnsealWithoutTemplateIgnoresTemplate checks that UnsealWithoutTemplate never renders spec.template.data.
+func TestUnsealWithoutTemplateIgnoresTemplate(t *testing.T) {
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myname",
+			Namespace: "myns",
+		},
+		Data: map[string][]byte{
+			"password": []byte("hunter2"),
+		},
+	}
+
+	ssecret, _, keys := sealSecret(t, &secret, NewSealedSecret)
+
+	// This probe template must not affect decryption or leak into the output.
+	ssecret.Spec.Template.Data = map[string]*string{
+		"probe": someStr(`{{ if eq .password "hunter2" }}{{ fail "guessed it" }}{{ end }}`),
+	}
+
+	unsealed, err := ssecret.UnsealWithoutTemplate(serializer.CodecFactory{}, keys)
+	if err != nil {
+		t.Fatalf("UnsealWithoutTemplate returned error for a decryptable secret with a template: %v", err)
+	}
+	if got, want := string(unsealed.Data["password"]), "hunter2"; got != want {
+		t.Errorf("password: got %q, want %q", got, want)
+	}
+	if _, ok := unsealed.Data["probe"]; ok {
+		t.Errorf("UnsealWithoutTemplate must not render spec.template.data, but found rendered key %q", "probe")
+	}
+
+	// Sanity check: genuinely undecryptable data must still fail.
+	_, otherKeys := generateTestKey(t, testRand(), 2048)
+	if _, err := ssecret.UnsealWithoutTemplate(serializer.CodecFactory{}, otherKeys); err == nil {
+		t.Errorf("UnsealWithoutTemplate did not return an error for encryptedData undecryptable with the given keys")
+	}
+}
+
 // TestTemplateDataPlaintextReference verifies that plaintext keys defined
 // in spec.template.data can be referenced from sibling templates as
 // {{ .key }} variables. Regression test for

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -574,7 +574,7 @@ func (c *Controller) Rotate(content []byte) ([]byte, error) {
 			slog.Warn("Sealed Secret metadata doesn't match. Please align your Sealed Secret metadata")
 		}
 
-		secret, err := c.attemptUnseal(s)
+		secret, err := c.attemptUnsealForRotate(s)
 		if err != nil {
 			return nil, fmt.Errorf("error decrypting secret. %v", err)
 		}
@@ -602,4 +602,9 @@ func (c *Controller) attemptUnseal(ss *ssv1alpha1.SealedSecret) (*corev1.Secret,
 
 func attemptUnseal(ss *ssv1alpha1.SealedSecret, keyRegistry *KeyRegistry) (*corev1.Secret, error) {
 	return ss.Unseal(scheme.Codecs, keyRegistry.privateKeys())
+}
+
+// attemptUnsealForRotate decrypts without rendering the template, since /v1/rotate is unauthenticated and the template could be used as a decryption oracle.
+func (c *Controller) attemptUnsealForRotate(ss *ssv1alpha1.SealedSecret) (*corev1.Secret, error) {
+	return ss.UnsealWithoutTemplate(scheme.Codecs, c.keyRegistry.privateKeys())
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -470,3 +470,79 @@ func TestAttemptUnsealIgnoresTemplate(t *testing.T) {
 		t.Errorf("AttemptUnseal reported a decryptable secret as invalid because of an unrelated template failure")
 	}
 }
+
+// TestRotateIgnoresTemplate checks that Rotate never executes spec.template.data as a template.
+func TestRotateIgnoresTemplate(t *testing.T) {
+	ns := "some-namespace"
+	keyNs := "some-key-namespace"
+	var tweakopts func(*metav1.ListOptions)
+	clientset := fake.NewClientset()
+	ssc := ssfake.NewSimpleClientset()
+	keyRegistry := testKeyRegister(t, context.Background(), clientset, ns)
+
+	validFor := time.Hour
+	cn := "my-cn"
+	_, err := keyRegistry.generateKey(context.Background(), validFor, cn, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controller, err := prepareController(clientset, ns, keyNs, tweakopts, &Flags{SkipRecreate: false}, ssc, keyRegistry)
+	if err != nil {
+		t.Fatalf("err %v want %v", err, nil)
+	}
+
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ss",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"password": []byte("hunter2"),
+		},
+	}
+
+	cert, err := controller.keyRegistry.getCert()
+	if err != nil {
+		t.Fatalf("error getting certificate: %v", err)
+	}
+
+	ssecret, err := ssv1alpha1.NewSealedSecret(scheme.Codecs, cert.PublicKey.(*rsa.PublicKey), secret)
+	if err != nil {
+		t.Fatalf("error creating sealed secrets: %v", err)
+	}
+
+	// Attacker-controlled, always-failing template paired with the victim's real data.
+	ssecret.Spec.Template.Data = map[string]*string{
+		"probe": someStr(`{{ fail "attacker-controlled failure" }}`),
+	}
+
+	enc, err := prettyEncoder(scheme.Codecs, runtime.ContentTypeJSON, ssv1alpha1.SchemeGroupVersion)
+	if err != nil {
+		t.Fatalf("unexpected pretty encoding: %v", err)
+	}
+	data, err := runtime.Encode(enc, ssecret)
+	if err != nil {
+		t.Fatalf("unexpected encoding the sealed secret: %v", err)
+	}
+
+	if _, err := controller.Rotate(data); err != nil {
+		t.Errorf("Rotate returned error for a decryptable secret because of an unrelated template failure: %v", err)
+	}
+
+	// Different guesses against the same ciphertext must behave identically.
+	ssecret.Spec.Template.Data = map[string]*string{
+		"probe": someStr(`{{ if eq .password "hunter2" }}{{ fail "guessed it" }}{{ end }}`),
+	}
+	data2, err := runtime.Encode(enc, ssecret)
+	if err != nil {
+		t.Fatalf("unexpected encoding the sealed secret: %v", err)
+	}
+	if _, err := controller.Rotate(data2); err != nil {
+		t.Errorf("Rotate must not turn template execution into a decryption oracle, got error: %v", err)
+	}
+}


### PR DESCRIPTION
Rotate() decrypted via the full Unseal() path, which renders spec.template.data as a Go template. That field isn't covered by the AEAD label, so an attacker able to submit a SealedSecret manifest to the unauthenticated /v1/rotate endpoint could pair a victim's real metadata/encryptedData with a crafted template and use the resulting success/error response as a one-bit decryption oracle - the same class of issue previously fixed for /v1/verify in 66db186e.

Add UnsealWithoutTemplate, which decrypts spec.encryptedData without ever executing spec.template.data, and use it in Rotate() instead.
