### PR TITLE
fix(controller): cap request body size on /v1/verify and /v1/rotate

### DIFF
--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"io"
 	"log"
 	"log/slog"
@@ -23,6 +24,33 @@ var (
 	readTimeout       = flag.Duration("read-timeout", 2*time.Minute, "HTTP request timeout.")
 	writeTimeout      = flag.Duration("write-timeout", 2*time.Minute, "HTTP response timeout.")
 )
+
+// maxRequestBodyBytes caps the body accepted by /v1/verify and /v1/rotate,
+// which is read fully into memory before rate limiting or crypto runs.
+// 10 MiB stays well above etcd's ~1.5 MiB object size limit (so no legitimate
+// SealedSecret is rejected) while bounding the memory an unauthenticated
+// caller can force the process to allocate per request.
+const maxRequestBodyBytes = 10 * 1024 * 1024
+
+// readLimitedBody reads r.Body up to maxRequestBodyBytes, writing an
+// appropriate status code (413 if the cap was exceeded, 400 for any other
+// read error) and returning ok=false if the read failed.
+func readLimitedBody(w http.ResponseWriter, r *http.Request, logMsg string) (content []byte, ok bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	content, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			slog.Error(logMsg, "error", err)
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return nil, false
+		}
+		slog.Error(logMsg, "error", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return nil, false
+	}
+	return content, true
+}
 
 // Called on every request to /cert.  Errors will be logged and return a 500.
 type certProvider func() ([]*x509.Certificate, error)
@@ -69,10 +97,8 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 	})
 
 	mux.Handle("/v1/verify", Instrument("/v1/verify", httpRateLimiter.RateLimit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		content, err := io.ReadAll(r.Body)
-		if err != nil {
-			slog.Error("Error handling /v1/verify request", "error", err)
-			w.WriteHeader(http.StatusBadRequest)
+		content, ok := readLimitedBody(w, r, "Error handling /v1/verify request")
+		if !ok {
 			return
 		}
 
@@ -92,10 +118,8 @@ func httpserver(cp certProvider, sc secretChecker, sr secretRotator, burst int, 
 
 	// TODO(mkm): rename to re-encrypt
 	mux.Handle("/v1/rotate", Instrument("/v1/rotate", httpRateLimiter.RateLimit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		content, err := io.ReadAll(r.Body)
-		if err != nil {
-			slog.Error("Error handling /v1/rotate request", "error", err)
-			w.WriteHeader(http.StatusBadRequest)
+		content, ok := readLimitedBody(w, r, "Error handling /v1/rotate request")
+		if !ok {
 			return
 		}
 

--- a/pkg/controller/server_test.go
+++ b/pkg/controller/server_test.go
@@ -120,6 +120,29 @@ func TestHttpCert(t *testing.T) {
 	check(certAfter)
 }
 
+func TestHttpVerifyRejectsOversizedBody(t *testing.T) {
+	sc := func([]byte) (bool, error) { return true, nil }
+	server := httpserver(nil, sc, nil, 2, 2, nil)
+	defer shutdownServer(server, t)
+
+	hp := *listenAddr
+	if strings.HasPrefix(hp, ":") {
+		hp = fmt.Sprintf("localhost%s", hp)
+	}
+	waitForServer(t, hp)
+
+	oversized := strings.NewReader(strings.Repeat("a", maxRequestBodyBytes+1))
+	resp, err := http.Post(fmt.Sprintf("http://%s/v1/verify", hp), "application/json", oversized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got, want := resp.StatusCode, http.StatusRequestEntityTooLarge; got != want {
+		t.Fatalf("got: %v, want: %v", got, want)
+	}
+}
+
 func TestHttpReadyz(t *testing.T) {
 	ready := false
 	server := httpserver(func() ([]*x509.Certificate, error) {


### PR DESCRIPTION
Both handlers read the full request body via io.ReadAll before rate limiting or crypto runs, letting an unauthenticated caller force unbounded memory allocation with an oversized payload. Wrap the body in http.MaxBytesReader (10 MiB) and return 413 when the cap is exceeded.
